### PR TITLE
Add Gaia theme

### DIFF
--- a/src/marp.ts
+++ b/src/marp.ts
@@ -1,6 +1,7 @@
 /* tslint:disable: import-name */
 import { Marpit } from '@marp-team/marpit'
 import defaultTheme from '../themes/default.scss'
+import gaiaTheme from '../themes/gaia.scss'
 
 export class Marp extends Marpit {
   themeSet: any
@@ -9,5 +10,8 @@ export class Marp extends Marpit {
     super(...args)
 
     this.themeSet.default = this.themeSet.add(defaultTheme)
+    this.themeSet.add(gaiaTheme)
   }
 }
+
+export default Marp

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -1,0 +1,235 @@
+/*
+ * Marp / Marpit Gaia theme.
+ *
+ * @theme gaia
+ * @author Yuki Hattori
+ */
+
+$color-light: #fff8e1;
+$color-dark: #455a64;
+$color-primary: #0288d1;
+$color-secondary: #81d4fa;
+
+@import url('https://fonts.googleapis.com/css?family=Lato:400,900|Roboto+Mono:400,700');
+
+@mixin color-scheme($bg, $text, $highlight) {
+  color: $text;
+  background-color: $bg;
+
+  a,
+  mark {
+    color: $highlight;
+  }
+
+  code {
+    background: mix($text, $bg, 80%);
+    color: $bg;
+  }
+
+  pre > code {
+    background: $text;
+  }
+
+  header,
+  footer,
+  section::after,
+  blockquote::before,
+  blockquote::after {
+    color: mix($text, $bg, 80%);
+  }
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0.5em 0 0 0;
+}
+
+h1 {
+  font-size: 1.8em;
+}
+
+h2 {
+  font-size: 1.5em;
+}
+
+h3 {
+  font-size: 1.3em;
+}
+
+h4 {
+  font-size: 1.1em;
+}
+
+h5 {
+  font-size: 1em;
+}
+
+h6 {
+  font-size: 0.9em;
+}
+
+p,
+blockquote {
+  margin: 1em 0 0 0;
+}
+
+ul,
+ol {
+  > li {
+    margin: 0.3em 0 0 0;
+
+    > p {
+      margin: 0.6em 0 0 0;
+    }
+  }
+}
+
+code {
+  display: inline-block;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.8em;
+  letter-spacing: 0;
+  margin: -0.1em 0.15em;
+  padding: 0.1em 0.2em;
+  vertical-align: baseline;
+}
+
+pre {
+  display: block;
+  overflow: auto;
+
+  code {
+    box-sizing: border-box;
+    margin: 0;
+    min-width: 100%;
+    padding: 0.5em;
+    font-size: 0.7em;
+  }
+}
+
+blockquote {
+  padding: 0 1em;
+  position: relative;
+
+  &::after,
+  &::before {
+    content: '“';
+    display: block;
+    font-family: 'Times New Roman', serif;
+    font-weight: bold;
+    position: absolute;
+  }
+
+  &::before {
+    top: 0;
+    left: 0;
+  }
+
+  &::after {
+    right: 0;
+    bottom: 0;
+    transform: rotate(180deg);
+  }
+
+  > *:first-child {
+    margin-top: 0;
+  }
+}
+
+mark {
+  background: transparent;
+}
+
+section {
+  background-image: linear-gradient(
+    135deg,
+    rgba(#888, 0),
+    rgba(#888, 0.02) 50%,
+    rgba(#fff, 0) 50%,
+    rgba(#fff, 0.05)
+  );
+  font-size: 35px;
+  font-family: 'Lato', 'Avenir Next', 'Avenir', 'Trebuchet MS', 'Segoe UI',
+    sans-serif;
+  line-height: 1.35;
+  letter-spacing: 1.25px;
+  padding: 70px;
+
+  > *:first-child,
+  > header:first-child + * {
+    margin-top: 0;
+  }
+
+  @include color-scheme($color-light, $color-dark, $color-primary);
+
+  &.invert {
+    @include color-scheme($color-dark, $color-light, $color-secondary);
+  }
+
+  &.gaia {
+    @include color-scheme($color-primary, $color-light, $color-secondary);
+  }
+
+  &.lead {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    justify-content: center;
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p {
+      text-align: center;
+    }
+
+    blockquote {
+      > h1,
+      > h2,
+      > h3,
+      > h4,
+      > h5,
+      > h6,
+      > p {
+        text-align: left;
+      }
+    }
+  }
+}
+
+header,
+footer,
+section::after {
+  box-sizing: border-box;
+  font-size: 66%;
+  height: 70px;
+  line-height: 50px;
+  overflow: hidden;
+  padding: 10px 25px;
+  position: absolute;
+}
+
+header {
+  left: 0;
+  right: 0;
+  top: 0;
+}
+
+footer {
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+section::after {
+  right: 0;
+  bottom: 0;
+  font-size: 80%;
+}

--- a/themes/gaia.scss.d.ts
+++ b/themes/gaia.scss.d.ts
@@ -1,0 +1,2 @@
+declare const theme: string
+export default theme


### PR DESCRIPTION
This PR will add Gaia theme that is based on Marpit theme CSS.

There is not a major change in a slide design. However, a few additional features for Gaia theme are changed how to use because of inconsistent features between themes.

- Auto-centering feature is omitted. When you want to use it for [the title slide](https://speakerdeck.com/yhatt/introducing-marps-gaia-theme?slide=9), you must add `lead` class manually.
- Currently, we are not supporting a [highlight markup](https://speakerdeck.com/yhatt/introducing-marps-gaia-theme?slide=12) (and we don't plan to implement at moment) but we are keeping the style for `<mark>` element for highlighting by HTML.
- Color scheme can select with Marpit's `class` directive instead of `template` directive.