### PR TITLE
Collect test coverage by CircleCI build artifacts and Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,8 @@ jobs:
           environment:
             JEST_JUNIT_OUTPUT: tmp/test-results/jest.xml
 
+      - run: codecov
+
       - store_test_results:
           path: tmp/test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,3 +45,7 @@ jobs:
 
       - store_test_results:
           path: tmp/test-results
+
+      - store_artifacts:
+          path: ./coverage
+          destination: coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           environment:
             JEST_JUNIT_OUTPUT: tmp/test-results/jest.xml
 
-      - run: codecov
+      - run: yarn codecov
 
       - store_test_results:
           path: tmp/test-results

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # @marp-team/marp-core
 
+[![CircleCI](https://img.shields.io/circleci/project/github/marp-team/marp-core/master.svg?style=flat-square)](https://circleci.com/gh/marp-team/marp-core/)
+
 **[The core of Marp](https://github.com/marp-team/marp-core) converter.** It has extended **[Marpit](https://github.com/marp-team/marpit)** the slide deck framework, that includes theme set for Marp family.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # @marp-team/marp-core
 
 [![CircleCI](https://img.shields.io/circleci/project/github/marp-team/marp-core/master.svg?style=flat-square)](https://circleci.com/gh/marp-team/marp-core/)
+[![Codecov](https://img.shields.io/codecov/c/github/marp-team/marp-core/master.svg?style=flat-square)](https://codecov.io/gh/marp-team/marp-core)
 
 **[The core of Marp](https://github.com/marp-team/marp-core) converter.** It has extended **[Marpit](https://github.com/marp-team/marpit)** the slide deck framework, that includes theme set for Marp family.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@types/jest": "^23.0.0",
     "autoprefixer": "^8.6.0",
+    "codecov": "^3.0.2",
     "github-markdown-css": "^2.10.0",
     "jest": "^23.1.0",
     "jest-junit": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,6 +196,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argv@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -857,6 +861,14 @@ coa@~1.0.1:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+codecov@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.0.2.tgz#aea43843a5cd2fb6b7e488b2eff25d367ab70b12"
+  dependencies:
+    argv "0.0.2"
+    request "^2.81.0"
+    urlgrey "0.4.4"
 
 collapse-white-space@^1.0.2:
   version "1.0.4"
@@ -4506,7 +4518,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@2, request@^2.83.0:
+request@2, request@^2.81.0, request@^2.83.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -5513,6 +5525,10 @@ uri-js@^4.2.1:
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+
+urlgrey@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
 
 use@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
This PR collects test coverage by CircleCI build artifacts and Codecov.

[Marpit](https://github.com/marp-team/marpit) framework has used mocha + nyc + TravisCI + coveralls. However, we are trying better tools in developing.

CircleCI can store the outputted coverage report as build artifacts. We will store Jest's coverage report, and we can see report graphically by HTML. Also Codecov outputs a nice coverage report than coveralls.

TypeScript + Jest + CircleCI + Codecov may become the standard assets for Marp family.