### PR TITLE
Add html constructor option

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "typescript": "^2.9.2"
   },
   "dependencies": {
-    "@marp-team/marpit": "^0.0.8",
+    "@marp-team/marpit": "^0.0.9",
     "highlight.js": "^9.12.0",
     "markdown-it-emoji": "^1.4.0"
   }

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -17,6 +17,7 @@ export class Marp extends Marpit {
           breaks: true,
           highlight: (code: string, lang: string) =>
             this.highlighter(code, lang),
+          html: opts.html !== undefined ? opts.html : false,
           linkify: true,
         },
       ],

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -1,15 +1,16 @@
 /* tslint:disable: import-name */
-import { Marpit } from '@marp-team/marpit'
+import { Marpit, MarpitOptions } from '@marp-team/marpit'
 import highlightjs from 'highlight.js'
 import markdownItEmoji from 'markdown-it-emoji'
 import defaultTheme from '../themes/default.scss'
 import gaiaTheme from '../themes/gaia.scss'
 
-export class Marp extends Marpit {
-  themeSet: any
-  markdown: any
+interface MarpOptions extends MarpitOptions {
+  html?: boolean
+}
 
-  constructor(opts: object = {}) {
+export class Marp extends Marpit {
+  constructor(opts: MarpOptions = {}) {
     super({
       markdown: [
         'commonmark',
@@ -22,7 +23,7 @@ export class Marp extends Marpit {
         },
       ],
       ...opts,
-    })
+    } as MarpitOptions)
 
     // Enable table
     this.markdown.enable(['table', 'linkify'])
@@ -32,7 +33,7 @@ export class Marp extends Marpit {
     this.themeSet.add(gaiaTheme)
   }
 
-  applyMarkdownItPlugins(md: any = this.markdown) {
+  applyMarkdownItPlugins(md = this.markdown) {
     super.applyMarkdownItPlugins(md)
 
     // Emoji shorthand

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -5,7 +5,7 @@ import markdownItEmoji from 'markdown-it-emoji'
 import defaultTheme from '../themes/default.scss'
 import gaiaTheme from '../themes/gaia.scss'
 
-interface MarpOptions extends MarpitOptions {
+export interface MarpOptions extends MarpitOptions {
   html?: boolean
 }
 

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -1,10 +1,10 @@
 import { Marpit } from '@marp-team/marpit'
 import cheerio from 'cheerio'
 import context from './_helpers/context'
-import { Marp } from '../src/marp'
+import { Marp, MarpOptions } from '../src/marp'
 
 describe('Marp', () => {
-  const marp = (...opts): Marp => new Marp(...opts)
+  const marp = (opts?: MarpOptions): Marp => new Marp(opts)
 
   it('extends Marpit', () => expect(marp()).toBeInstanceOf(Marpit))
 

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -4,7 +4,7 @@ import context from './_helpers/context'
 import { Marp } from '../src/marp'
 
 describe('Marp', () => {
-  const marp = (): Marp => new Marp()
+  const marp = (...opts): Marp => new Marp(...opts)
 
   it('extends Marpit', () => expect(marp()).toBeInstanceOf(Marpit))
 
@@ -32,6 +32,24 @@ describe('Marp', () => {
       )
       expect($('h1').html()).toBe($('h2').html())
       expect($('h1 > span[data-marpit-emoji]').length).toBe(1)
+    })
+  })
+
+  describe('html option', () => {
+    it('sanitizes HTML tag by default', () => {
+      const { html } = marp().render('<b>abc</b>')
+      const $ = cheerio.load(html)
+
+      expect($('b').length).toBe(0)
+    })
+
+    context('with true', () => {
+      it('renders HTML tag', () => {
+        const { html } = marp({ html: true }).render('<b>abc</b>')
+        const $ = cheerio.load(html)
+
+        expect($('b').length).toBe(1)
+      })
     })
   })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
+    "lib": ["es2016"],
     "module": "commonjs",
     "noImplicitAny": false,
     "outDir": "lib",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "commonjs",
-    "noImplicitAny": false, // TODO: Remove this line after defined Marpit's type
+    "noImplicitAny": false,
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,16 +33,16 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@marp-team/marpit@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.0.8.tgz#8e07d8713d36c8e53f76eccd5071da0f8b7dda1a"
+"@marp-team/marpit@^0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.0.9.tgz#868bc4431d29887cf71ec8576336e3795238d166"
   dependencies:
     emoji-regex "^7.0.0"
     js-yaml "^3.12.0"
     lodash.kebabcase "^4.1.1"
-    markdown-it "^8.4.1"
+    markdown-it "^8.4.2"
     markdown-it-front-matter "^0.1.2"
-    postcss "^6.0.23"
+    postcss "^7.0.1"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -3314,9 +3314,9 @@ markdown-it-front-matter@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/markdown-it-front-matter/-/markdown-it-front-matter-0.1.2.tgz#e50bf56e77e6a4f5ac4ffa894d4d45ccd9896b20"
 
-markdown-it@^8.4.1:
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.1.tgz#206fe59b0e4e1b78a7c73250af9b34a4ad0aaf44"
+markdown-it@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
   dependencies:
     argparse "^1.0.7"
     entities "~1.1.1"
@@ -4343,6 +4343,14 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
 postcss@^6.0.23:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
+
+postcss@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.1.tgz#db20ca4fc90aa56809674eea75864148c66b67fa"
   dependencies:
     chalk "^2.4.1"
     source-map "^0.6.1"


### PR DESCRIPTION
This PR will add `html`constructor option on Marp class to switch rendering HTML tag. The default is `false`.

We are planning the next Marp that will become to release on web platform (*@marp-team/marp-web*), so we must consider about security well.

The pre-released desktop app had allowed user HTML (or JavaScript) to customize your slide. It has a lot of flexibility for power user (e.g. yhatt/marp#29). Meanwhile, it might leak system level permission (e.g. [CVE-2017-2239](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-2239)). We should always pay attention to expose to threats like zero-day vulnerability.

We have discussed sanitizing HTML by whitelist or blacklist at yhatt/marp#187. And now, we will disallow *any* HTML on Marp Markdown by default.

But no worries, we are going to provide other ways for the power user to use HTML on Marp slide.  The CLI interface (@marp-team/marp-cli) would provide an option like --html=true. The modularized packages by @marp-team (like [@marp-team/marp-core](https://github.com/marp-team/marp-core) or [@marp-team/marpit](https://github.com/marp-team/marpit)) would help the developer to create slides with HTML.