### PR TITLE
Math typesetting support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run:
           name: Jest
           command:
-            yarn test --ci --coverage --runInBand --reporters=default --reporters=jest-junit
+            yarn test --ci --coverage --maxWorkers=2 --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT: tmp/test-results/jest.xml
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,3 @@ Managed by [@marp-team](https://github.com/marp-team).
 ## License
 
 [MIT License](LICENSE)
-
-```
-
-```

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ $$
 </tbody>
 </table>
 
-## Constructor option
+## Constructor options
 
-You can customize a behavior of Marp parser by passing option argument to the constructor. You can also pass together with [Marpit's constructor option](https://marpit.netlify.com/marpit#Marpit).
+You can customize a behavior of Marp parser by passing an options object to the constructor. You can also pass together with [Marpit constructor options](https://marpit.netlify.com/marpit#Marpit).
 
 ```javascript
 const marp = new Marp({
@@ -78,21 +78,21 @@ const marp = new Marp({
 })
 ```
 
-### `html`: <small>`boolean`</small>
+### `html`: _`boolean`_
 
 Setting whether to render raw HTML in Markdown. The default value is `true`.
 
-Even if you are setting `false`, `<!-- HTML comment -->` is always parsed by Marpit for directives. When you are not disabled Marpit's `inlineStyle` option by `false`, `<style>` tag are parsed too for tweaking theme style.
+Even if you are setting `false`, `<!-- HTML comment -->` is always parsed by Marpit for directives. When you are not disabled [Marpit's `inlineStyle` option](https://marpit.netlify.com/marpit#Marpit) by `false`, `<style>` tags are parsed too for tweaking theme style.
 
-### `math`: <small>`boolean` | `object`</small>
+### `math`: _`boolean` | `object`_
 
 Enable or disable [math typesetting](#math-typesetting) syntax. The default value is `true`.
 
 You can modify KaTeX further settings by passing an object of sub-options.
 
-- **`katexOption`**: `object`
+- **`katexOption`**: _`object`_
   - The options passing to KaTeX. Please refer to [KaTeX document](https://khan.github.io/KaTeX/docs/options.html).
-- **`katexFontPath`**: `string` | `false`
+- **`katexFontPath`**: _`string` | `false`_
   - By default, marp-core will use [online web-font resources through jsDelivr CDN](https://cdn.jsdelivr.net/npm/katex@latest/dist/fonts/). You have to set path to fonts directory if you want to use local resources. If you set `false`, we will not manipulate the path (Use KaTeX's original path: `fonts/KaTeX_***-***.woff2`).
 
 <!-- ## [Work in progress] Themes -->

--- a/README.md
+++ b/README.md
@@ -3,4 +3,110 @@
 [![CircleCI](https://img.shields.io/circleci/project/github/marp-team/marp-core/master.svg?style=flat-square)](https://circleci.com/gh/marp-team/marp-core/)
 [![Codecov](https://img.shields.io/codecov/c/github/marp-team/marp-core/master.svg?style=flat-square)](https://codecov.io/gh/marp-team/marp-core)
 
-**[The core of Marp](https://github.com/marp-team/marp-core) converter.** It has extended **[Marpit](https://github.com/marp-team/marpit)** the slide deck framework, that includes theme set for Marp family.
+**The core of [Marp](https://github.com/marp-team/marp) converter.**
+
+In order to use on Marp tools, we have extended from the slide deck framework **[Marpit](https://github.com/marp-team/marpit)**. You can use the practical Markdown syntax, advanced features, and official themes.
+
+### :warning: _marp-core is under construction and not ready to use._
+
+## Basic usage
+
+We provide `Marp` class, that is inherited from [Marpit](https://github.com/marp-team/marpit).
+
+```javascript
+import Marp from '@marp-team/marp-core'
+
+// Convert Markdown slide deck into HTML and CSS
+const marp = new Marp()
+const { html, css } = marp.render('# Hello, marp-core!')
+```
+
+## Features
+
+_We will only explain features extended in marp-core._ Please refer [@marp-team/marpit](https://github.com/marp-team/marpit) repository to if you want to know the basic feature of Marpit framework.
+
+### Math typesetting
+
+We have [Pandoc's Markdown style](https://pandoc.org/MANUAL.html#math) math typesetting support by [KaTeX](https://khan.github.io/KaTeX/). Surround your formula by `$...$` to render math as inline, and `$$...$$` to render as block.
+
+<table>
+<thead>
+<tr>
+<th style="text-align:center;">Markdown</th>
+<th style="text-align:center;">Rendered slide</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+
+```tex
+Render inline math such as $ax^2+bc+c$.
+
+$$ I_{xx}=\int\int_Ry^2f(x,y)\cdot{}dydx $$
+
+$$
+f(x) = \int_{-\infty}^\infty
+    \hat f(\xi)\,e^{2 \pi i \xi x}
+    \,d\xi
+$$
+```
+
+</td>
+<td>
+
+![Math typesetting support](https://user-images.githubusercontent.com/3993388/43712050-cea4dd94-99af-11e8-9ea7-e2c49e0f07c1.png)
+
+</td>
+</tbody>
+</table>
+
+## Constructor option
+
+You can customize a behavior of Marp parser by passing option argument to the constructor. You can also pass together with [Marpit's constructor option](https://marpit.netlify.com/marpit#Marpit).
+
+```javascript
+const marp = new Marp({
+  // marp-core constructor options
+  html: false,
+  math: {
+    katexFontPath: '/resources/fonts/',
+  },
+
+  // Marpit constructor options
+  inlineSVG: true,
+})
+```
+
+### `html`: <small>`boolean`</small>
+
+Setting whether to render raw HTML in Markdown. The default value is `true`.
+
+Even if you are setting `false`, `<!-- HTML comment -->` is always parsed by Marpit for directives. When you are not disabled Marpit's `inlineStyle` option by `false`, `<style>` tag are parsed too for tweaking theme style.
+
+### `math`: <small>`boolean` | `object`</small>
+
+Enable or disable [math typesetting](#math-typesetting) syntax. The default value is `true`.
+
+You can modify KaTeX further settings by passing an object of sub-options.
+
+- **`katexOption`**: `object`
+  - The options passing to KaTeX. Please refer to [KaTeX document](https://khan.github.io/KaTeX/docs/options.html).
+- **`katexFontPath`**: `string` | `false`
+  - By default, marp-core will use [online web-font resources through jsDelivr CDN](https://cdn.jsdelivr.net/npm/katex@latest/dist/fonts/). You have to set path to fonts directory if you want to use local resources. If you set `false`, we will not manipulate the path (Use KaTeX's original path: `fonts/KaTeX_***-***.woff2`).
+
+<!-- ## [Work in progress] Themes -->
+
+## Author
+
+Managed by [@marp-team](https://github.com/marp-team).
+
+- <img src="https://github.com/yhatt.png" width="16" height="16"/> Yuki Hattori ([@yhatt](https://github.com/yhatt))
+
+## License
+
+[MIT License](LICENSE)
+
+```
+
+```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ const marp = new Marp({
 
 ### `html`: _`boolean`_
 
-Setting whether to render raw HTML in Markdown. The default value is `true`.
+Setting whether to render raw HTML in Markdown. The default value is **`false`** for security reason.
 
 Even if you are setting `false`, `<!-- HTML comment -->` is always parsed by Marpit for directives. When you are not disabled [Marpit's `inlineStyle` option](https://marpit.netlify.com/marpit#Marpit) by `false`, `<style>` tags are parsed too for tweaking theme style.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,10 @@
 module.exports = {
   collectCoverageFrom: ['src/**/*.{j,t}s'],
+  coveragePathIgnorePatterns: ['/node_modules/', '.*\\.d\\.ts'],
   coverageThreshold: { global: { lines: 95 } },
   transform: {
     '^.*\\.ts$': 'ts-jest',
+    '^.*katex\\.s?css$': '<rootDir>/test/_transformers/katex_css.ts',
     '^.*\\.s?css$': '<rootDir>/test/_transformers/css.ts',
   },
   testRegex: '(/(test|__tests__)/(?!_).*|(\\.|/)(test|spec))\\.[jt]s$',

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@marp-team/marpit": "^0.0.9",
     "highlight.js": "^9.12.0",
     "katex": "^0.10.0-beta",
-    "markdown-it-emoji": "^1.4.0"
+    "markdown-it-emoji": "^1.4.0",
+    "markdown-it-katex": "^2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "highlight.js": "^9.12.0",
     "katex": "^0.10.0-beta",
     "markdown-it-emoji": "^1.4.0",
-    "markdown-it-katex": "^2.0.3"
+    "markdown-it-katex": "^2.0.3",
+    "postcss": "^7.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "@marp-team/marpit": "^0.0.9",
     "highlight.js": "^9.12.0",
+    "katex": "^0.10.0-beta",
     "markdown-it-emoji": "^1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "watch": "rollup -w -c"
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0-beta.55",
+    "@babel/core": "^7.0.0-beta.56",
     "@types/cheerio": "^0.22.8",
     "@types/jest": "^23.3.1",
     "autoprefixer": "^9.1.0",
@@ -55,14 +55,14 @@
     "stylelint-config-prettier": "^3.3.0",
     "stylelint-config-standard": "^18.2.0",
     "stylelint-scss": "^3.2.0",
-    "ts-jest": "^23.1.1",
+    "ts-jest": "^23.1.2",
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.9.2",
     "tslint-config-prettier": "^1.14.0",
     "typescript": "^3.0.1"
   },
   "dependencies": {
-    "@marp-team/marpit": "^0.0.9",
+    "@marp-team/marpit": "^0.0.10",
     "highlight.js": "^9.12.0",
     "katex": "^0.10.0-beta",
     "markdown-it-emoji": "^1.4.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,10 @@ export default [
       json({ preferConst: true }),
       nodeResolve({ jsnext: true }),
       commonjs(),
-      typescriptPlugin({ typescript }),
+      typescriptPlugin({
+        resolveJsonModule: false, // JSON has already resolved by rollup-plugin-json
+        typescript,
+      }),
       postcss({
         inject: false,
         plugins: [autoprefixer()],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ import pkg from './package.json'
 
 export default [
   {
-    external: ['@marp-team/marpit'],
+    external: ['@marp-team/marpit', 'postcss'],
     input: `src/${path.basename(pkg.main, '.js')}.ts`,
     output: {
       name: 'marp-core',

--- a/src/markdown/katex.scss
+++ b/src/markdown/katex.scss
@@ -1,0 +1,1 @@
+@import '~katex/dist/katex.min';

--- a/src/markdown/katex.scss
+++ b/src/markdown/katex.scss
@@ -1,1 +1,5 @@
 @import '~katex/dist/katex.min';
+
+.katex-display {
+  margin: 0;
+}

--- a/src/markdown/katex.scss.d.ts
+++ b/src/markdown/katex.scss.d.ts
@@ -1,0 +1,2 @@
+declare const theme: string
+export default theme

--- a/src/markdown/katex.scss.d.ts
+++ b/src/markdown/katex.scss.d.ts
@@ -1,2 +1,2 @@
-declare const theme: string
-export default theme
+declare const katex: string
+export default katex

--- a/src/markdown/math.ts
+++ b/src/markdown/math.ts
@@ -1,0 +1,43 @@
+import katex from 'katex'
+import markdownItKatex from 'markdown-it-katex'
+import katexMinCss from 'katex/dist/katex.min.css'
+
+export function markdownItPlugin(md, katexOptions: object) {
+  const opts = (mergeOpts = {}) => ({
+    ...katexOptions,
+    ...mergeOpts,
+    throwOnError: true,
+  })
+
+  // Parse math syntax by using markdown-it-katex
+  md.use(markdownItKatex)
+
+  // Swap renderer to use the latest KaTeX
+  md.renderer.rules.math_inline = (tokens, idx) => {
+    const { content } = tokens[idx]
+    try {
+      return katex.renderToString(content, opts({ displayMode: false }))
+    } catch (e) {
+      console.warn(e)
+      return content
+    }
+  }
+
+  md.renderer.rules.math_block = (tokens, idx) => {
+    const { content } = tokens[idx]
+    try {
+      return `<p>${katex.renderToString(
+        content,
+        opts({ displayMode: true })
+      )}</p>`
+    } catch (e) {
+      console.warn(e)
+      return `<p>${content}</p>`
+    }
+  }
+}
+
+export function css() {
+  // TODO: Manipulate with PostCSS to change URL of KaTeX fonts
+  return katexMinCss
+}

--- a/src/markdown/math.ts
+++ b/src/markdown/math.ts
@@ -1,23 +1,54 @@
 import katex from 'katex'
 import markdownItKatex from 'markdown-it-katex'
 import postcss from 'postcss'
+import { Marp } from '../marp'
 import katexScss from './katex.scss'
 
-export function markdownItPlugin(md, katexOptions: object) {
+export function markdownItPlugin(
+  md,
+  marp: Marp,
+  katexOptions = {},
+  updateRendered: (isRendered: boolean) => void = () => {}
+) {
   const opts = (mergeOpts = {}) => ({
     throwOnError: false,
     ...katexOptions,
     ...mergeOpts,
   })
 
+  md.core.ruler.before('block', 'marp_math_initialize', state => {
+    if (!state.inlineMode) updateRendered(false)
+  })
+
   // Parse math syntax by using markdown-it-katex
   md.use(markdownItKatex)
+
+  const mathInline =
+    md.inline.ruler.__rules__[md.inline.ruler.__find__('math_inline')].fn
+
+  const mathBlock =
+    md.block.ruler.__rules__[md.block.ruler.__find__('math_block')].fn
+
+  md.inline.ruler.at('math_inline', (...args) => {
+    const ret = mathInline(...args)
+    if (ret) updateRendered(true)
+
+    return ret
+  })
+
+  md.block.ruler.at('math_block', (...args) => {
+    const ret = mathBlock(...args)
+    if (ret) updateRendered(true)
+
+    return ret
+  })
 
   // Swap renderer to use the latest KaTeX
   md.renderer.rules.math_inline = (tokens, idx) => {
     const { content } = tokens[idx]
     try {
-      return katex.renderToString(content, opts({ displayMode: false }))
+      const math = katex.renderToString(content, opts({ displayMode: false }))
+      return math
     } catch (e) {
       console.warn(e)
       return content
@@ -27,10 +58,11 @@ export function markdownItPlugin(md, katexOptions: object) {
   md.renderer.rules.math_block = (tokens, idx) => {
     const { content } = tokens[idx]
     try {
-      return `<p>${katex.renderToString(
+      const math = `<p>${katex.renderToString(
         content,
         opts({ displayMode: true })
       )}</p>`
+      return math
     } catch (e) {
       console.warn(e)
       return `<p>${content}</p>`

--- a/src/markdown/math.ts
+++ b/src/markdown/math.ts
@@ -9,7 +9,7 @@ export function markdownItPlugin(
   updateRendered: (isRendered: boolean) => void
 ) {
   const opts = mergeOpts => ({
-    throwOnError: true,
+    throwOnError: false,
     ...katexOptions,
     ...mergeOpts,
   })

--- a/src/markdown/math.ts
+++ b/src/markdown/math.ts
@@ -1,6 +1,6 @@
 import katex from 'katex'
 import markdownItKatex from 'markdown-it-katex'
-import katexMinCss from 'katex/dist/katex.min.css'
+import katexScss from './katex.scss'
 
 export function markdownItPlugin(md, katexOptions: object) {
   const opts = (mergeOpts = {}) => ({
@@ -39,5 +39,5 @@ export function markdownItPlugin(md, katexOptions: object) {
 
 export function css() {
   // TODO: Manipulate with PostCSS to change URL of KaTeX fonts
-  return katexMinCss
+  return katexScss
 }

--- a/src/markdown/math.ts
+++ b/src/markdown/math.ts
@@ -4,9 +4,9 @@ import katexScss from './katex.scss'
 
 export function markdownItPlugin(md, katexOptions: object) {
   const opts = (mergeOpts = {}) => ({
+    throwOnError: false,
     ...katexOptions,
     ...mergeOpts,
-    throwOnError: true,
   })
 
   // Parse math syntax by using markdown-it-katex

--- a/src/markdown/math.ts
+++ b/src/markdown/math.ts
@@ -1,17 +1,15 @@
 import katex from 'katex'
 import markdownItKatex from 'markdown-it-katex'
 import postcss from 'postcss'
-import { Marp } from '../marp'
 import katexScss from './katex.scss'
 
 export function markdownItPlugin(
   md,
-  marp: Marp,
-  katexOptions = {},
-  updateRendered: (isRendered: boolean) => void = () => {}
+  katexOptions: object,
+  updateRendered: (isRendered: boolean) => void
 ) {
-  const opts = (mergeOpts = {}) => ({
-    throwOnError: false,
+  const opts = mergeOpts => ({
+    throwOnError: true,
     ...katexOptions,
     ...mergeOpts,
   })
@@ -72,7 +70,7 @@ export function markdownItPlugin(
 
 const katexDefaultFontPath = 'fonts/'
 
-const katexFontPath = (path = katexDefaultFontPath) => {
+const katexFontPath = path => {
   const pattern = `url\\(['"]?${katexDefaultFontPath}(.*?)['"]?\\)`
   const matcher = new RegExp(pattern, 'g')
 

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -14,6 +14,8 @@ export interface MarpOptions extends MarpitOptions {
 export class Marp extends Marpit {
   options!: MarpOptions
 
+  private renderedMath: boolean = false
+
   constructor(opts: MarpOptions = {}) {
     super({
       markdown: [
@@ -47,7 +49,9 @@ export class Marp extends Marpit {
       `<span data-marpit-emoji>${token[idx].content}</span>`
 
     // Math typesetting
-    if (this.options.math) md.use(mathMD)
+    md.use(mathMD, this, {}, isRendered => {
+      this.renderedMath = isRendered
+    })
   }
 
   highlighter(code: string, lang: string): string {
@@ -63,7 +67,7 @@ export class Marp extends Marpit {
     const base = { ...super.themeSetPackOptions() }
     const { math } = this.options
 
-    if (math) {
+    if (math && this.renderedMath) {
       // By default, we use KaTeX web fonts through CDN.
       let path: string | undefined =
         'https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/fonts/'

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -8,7 +8,12 @@ import gaiaTheme from '../themes/gaia.scss'
 
 export interface MarpOptions extends MarpitOptions {
   html?: boolean
-  math?: boolean | { katexFontPath?: string | false }
+  math?:
+    | boolean
+    | {
+        katexOption?: object
+        katexFontPath?: string | false
+      }
 }
 
 export class Marp extends Marpit {
@@ -49,9 +54,18 @@ export class Marp extends Marpit {
       `<span data-marpit-emoji>${token[idx].content}</span>`
 
     // Math typesetting
-    md.use(mathMD, this, {}, isRendered => {
-      this.renderedMath = isRendered
-    })
+    const { math } = this.options
+
+    if (math) {
+      const opts =
+        typeof math === 'object' && typeof math.katexOption === 'object'
+          ? math.katexOption
+          : {}
+
+      md.use(mathMD, opts, isRendered => {
+        this.renderedMath = isRendered
+      })
+    }
   }
 
   highlighter(code: string, lang: string): string {

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -1,15 +1,19 @@
 /* tslint:disable: import-name */
-import { Marpit, MarpitOptions } from '@marp-team/marpit'
+import { Marpit, MarpitOptions, ThemeSetPackOptions } from '@marp-team/marpit'
 import highlightjs from 'highlight.js'
 import markdownItEmoji from 'markdown-it-emoji'
+import { markdownItPlugin as mathMD, css as mathCSS } from './markdown/math'
 import defaultTheme from '../themes/default.scss'
 import gaiaTheme from '../themes/gaia.scss'
 
 export interface MarpOptions extends MarpitOptions {
   html?: boolean
+  math?: boolean | object
 }
 
 export class Marp extends Marpit {
+  options!: MarpOptions
+
   constructor(opts: MarpOptions = {}) {
     super({
       markdown: [
@@ -22,6 +26,7 @@ export class Marp extends Marpit {
           linkify: true,
         },
       ],
+      math: true,
       ...opts,
     } as MarpitOptions)
 
@@ -40,6 +45,9 @@ export class Marp extends Marpit {
     md.use(markdownItEmoji, { shortcuts: {} })
     md.renderer.rules.emoji = (token, idx) =>
       `<span data-marpit-emoji>${token[idx].content}</span>`
+
+    // Math typesetting
+    if (this.options.math) md.use(mathMD)
   }
 
   highlighter(code: string, lang: string): string {
@@ -49,6 +57,17 @@ export class Marp extends Marpit {
         : ''
     }
     return highlightjs.highlightAuto(code).value
+  }
+
+  protected themeSetPackOptions(): ThemeSetPackOptions {
+    const base = { ...super.themeSetPackOptions() }
+
+    if (this.options.math) {
+      // Add KaTeX css
+      base.before = `${mathCSS()}\n${base.before || ''}`
+    }
+
+    return base
   }
 }
 

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -8,7 +8,7 @@ import gaiaTheme from '../themes/gaia.scss'
 
 export interface MarpOptions extends MarpitOptions {
   html?: boolean
-  math?: boolean | object
+  math?: boolean | { katexFontPath?: string | false }
 }
 
 export class Marp extends Marpit {
@@ -61,10 +61,19 @@ export class Marp extends Marpit {
 
   protected themeSetPackOptions(): ThemeSetPackOptions {
     const base = { ...super.themeSetPackOptions() }
+    const { math } = this.options
 
-    if (this.options.math) {
+    if (math) {
+      // By default, we use KaTeX web fonts through CDN.
+      let path: string | undefined =
+        'https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/fonts/'
+
+      if (typeof math === 'object') {
+        path = math.katexFontPath === false ? undefined : math.katexFontPath
+      }
+
       // Add KaTeX css
-      base.before = `${mathCSS()}\n${base.before || ''}`
+      base.before = `${mathCSS(path)}\n${base.before || ''}`
     }
 
     return base

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -1,6 +1,7 @@
 /* tslint:disable: import-name */
 import { Marpit, MarpitOptions, ThemeSetPackOptions } from '@marp-team/marpit'
 import highlightjs from 'highlight.js'
+import katexPackage from 'katex/package.json'
 import markdownItEmoji from 'markdown-it-emoji'
 import { markdownItPlugin as mathMD, css as mathCSS } from './markdown/math'
 import defaultTheme from '../themes/default.scss'
@@ -83,8 +84,9 @@ export class Marp extends Marpit {
 
     if (math && this.renderedMath) {
       // By default, we use KaTeX web fonts through CDN.
-      let path: string | undefined =
-        'https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/fonts/'
+      let path: string | undefined = `https://cdn.jsdelivr.net/npm/katex@${
+        katexPackage.version
+      }/dist/fonts/`
 
       if (typeof math === 'object') {
         path = math.katexFontPath === false ? undefined : math.katexFontPath

--- a/test/_transformers/katex_css.ts
+++ b/test/_transformers/katex_css.ts
@@ -1,0 +1,20 @@
+const css = `
+@font-face {
+  font-family: KaTeX_Mock;
+  src: url(fonts/KaTeX_Mock.woff2) format('woff2'),
+    url('fonts/KaTeX_Mock.woff') format('woff'),
+    url("fonts/KaTeX_Mock.ttf") format('truetype');
+  font-weight: 400;
+  font-style: normal;
+}
+
+.katex {
+  display: inline;
+}
+`.trim()
+
+module.exports = {
+  process(src) {
+    return `module.exports = ${JSON.stringify(css)};`
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "noImplicitAny": false,
     "outDir": "lib",
+    "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
     "target": "es2015"

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,6 +266,10 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -818,6 +822,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  dependencies:
+    ansi-styles "~1.0.0"
+    has-color "~0.1.0"
+    strip-ansi "~0.1.0"
 
 character-entities-html4@^1.0.0:
   version "1.1.2"
@@ -1955,6 +1967,10 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-color@~0.1.0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
+
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
@@ -2955,6 +2971,13 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+katex@^0.10.0-beta:
+  version "0.10.0-beta"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.10.0-beta.tgz#82c9ccb21fbc92c5dbed67db3240e299969efffb"
+  dependencies:
+    match-at "^0.1.1"
+    nomnom "^1.8.1"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -3174,6 +3197,10 @@ markdown-it@^8.4.2:
 markdown-table@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
+
+match-at@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/match-at/-/match-at-0.1.1.tgz#25d040d291777704d5e6556bbb79230ec2de0540"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -3468,6 +3495,13 @@ node-sass@^4.9.2:
     sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
+
+nomnom@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
+  dependencies:
+    chalk "~0.4.0"
+    underscore "~1.6.0"
 
 "nopt@2 || 3":
   version "3.0.6"
@@ -5012,6 +5046,10 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-ansi@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
+
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -5416,6 +5454,10 @@ uglify-js@^2.6:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
+underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
 unherit@^1.0.4:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,6 +2978,12 @@ katex@^0.10.0-beta:
     match-at "^0.1.1"
     nomnom "^1.8.1"
 
+katex@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.6.0.tgz#12418e09121c05c92041b6b3b9fb6bab213cb6f3"
+  dependencies:
+    match-at "^0.1.0"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -3184,6 +3190,12 @@ markdown-it-front-matter@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/markdown-it-front-matter/-/markdown-it-front-matter-0.1.2.tgz#e50bf56e77e6a4f5ac4ffa894d4d45ccd9896b20"
 
+markdown-it-katex@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/markdown-it-katex/-/markdown-it-katex-2.0.3.tgz#d7b86a1aea0b9d6496fab4e7919a18fdef589c39"
+  dependencies:
+    katex "^0.6.0"
+
 markdown-it@^8.4.2:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
@@ -3198,7 +3210,7 @@ markdown-table@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
 
-match-at@^0.1.1:
+match-at@^0.1.0, match-at@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/match-at/-/match-at-0.1.1.tgz#25d040d291777704d5e6556bbb79230ec2de0540"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,23 +2,29 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.0.0-beta.55", "@babel/code-frame@^7.0.0-beta.35":
+"@babel/code-frame@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz#09f76300673ac085d3b90e02aafa0ffc2c96846a"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.56"
+
+"@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.55.tgz#71f530e7b010af5eb7a7df7752f78921dd57e9ee"
   dependencies:
     "@babel/highlight" "7.0.0-beta.55"
 
-"@babel/core@^7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-beta.55.tgz#9e17c34b5ac855e427c98f570915a17fcc6bab4a"
+"@babel/core@^7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-beta.56.tgz#cc03ffbb62564fef58fd1cefcbb3e32011c21df9"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.55"
-    "@babel/generator" "7.0.0-beta.55"
-    "@babel/helpers" "7.0.0-beta.55"
-    "@babel/parser" "7.0.0-beta.55"
-    "@babel/template" "7.0.0-beta.55"
-    "@babel/traverse" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/code-frame" "7.0.0-beta.56"
+    "@babel/generator" "7.0.0-beta.56"
+    "@babel/helpers" "7.0.0-beta.56"
+    "@babel/parser" "7.0.0-beta.56"
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/traverse" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
     convert-source-map "^1.1.0"
     debug "^3.1.0"
     json5 "^0.5.0"
@@ -27,43 +33,43 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.55.tgz#8ec11152dcc398bae35dd181122704415c383a01"
+"@babel/generator@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.56.tgz#07d9c2f45990c453130e080eddcd252a9cbd8d66"
   dependencies:
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
     jsesc "^2.5.1"
     lodash "^4.17.10"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/helper-function-name@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.55.tgz#16aab21380a2eabcee3328d21b9586ba3427dbef"
+"@babel/helper-function-name@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz#4e9c8a84ce4368b4a779409d0c4fe3f714be60ab"
   dependencies:
-    "@babel/helper-get-function-arity" "7.0.0-beta.55"
-    "@babel/template" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/helper-get-function-arity" "7.0.0-beta.56"
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helper-get-function-arity@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.55.tgz#8559ded96ecd3b626f9c1f57494edc4fa3cc6a94"
+"@babel/helper-get-function-arity@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz#872864d67e25705b94d1c71afc72344aafc8dc9c"
   dependencies:
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helper-split-export-declaration@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.55.tgz#ecb8074bf2d22c6518a252282535def137a8704f"
+"@babel/helper-split-export-declaration@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz#82d53382836134ba3ed0ea2394ca21fe579ec241"
   dependencies:
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helpers@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.0.0-beta.55.tgz#d0b4b9a327dba42d58890011deb905c820739617"
+"@babel/helpers@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.0.0-beta.56.tgz#a01cac1481c6fa38197ae410137539045b160443"
   dependencies:
-    "@babel/template" "7.0.0-beta.55"
-    "@babel/traverse" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/traverse" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
 
 "@babel/highlight@7.0.0-beta.55":
   version "7.0.0-beta.55"
@@ -73,36 +79,44 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/parser@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.55.tgz#0a527efc148c6c8cd85d5ffddacad817a2daeeb2"
-
-"@babel/template@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.55.tgz#c6cab0e2722ba5e33fe034073b6d31673aba326e"
+"@babel/highlight@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.56.tgz#f8b0fc8c5c2de53bb2c12f9001ad3d99e573696d"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.55"
-    "@babel/parser" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/parser@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.56.tgz#8638aa02e0130cd10b2ba4128e2b804112073ed3"
+
+"@babel/template@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.56.tgz#a428197e0c9db142f8581cbfdcfa9289b0dd7fd7"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.56"
+    "@babel/parser" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
     lodash "^4.17.10"
 
-"@babel/traverse@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.55.tgz#50be5d0fcc5cc4ac020a7b0c519be8dae345d4be"
+"@babel/traverse@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.56.tgz#62fdfe69328cfaad414ef01844f5ab40e32f4ad0"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.55"
-    "@babel/generator" "7.0.0-beta.55"
-    "@babel/helper-function-name" "7.0.0-beta.55"
-    "@babel/helper-split-export-declaration" "7.0.0-beta.55"
-    "@babel/parser" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/code-frame" "7.0.0-beta.56"
+    "@babel/generator" "7.0.0-beta.56"
+    "@babel/helper-function-name" "7.0.0-beta.56"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.56"
+    "@babel/parser" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
     debug "^3.1.0"
     globals "^11.1.0"
     lodash "^4.17.10"
 
-"@babel/types@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.55.tgz#7755c9d2e58315a64f05d8cf3322379be16d9199"
+"@babel/types@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.56.tgz#df456947a82510ec30361971e566110d89489056"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
@@ -125,16 +139,16 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@marp-team/marpit@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.0.9.tgz#868bc4431d29887cf71ec8576336e3795238d166"
+"@marp-team/marpit@^0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.0.10.tgz#a01a1a154f4a253b11e4bb40612c918250814b78"
   dependencies:
     emoji-regex "^7.0.0"
     js-yaml "^3.12.0"
     lodash.kebabcase "^4.1.1"
     markdown-it "^8.4.2"
     markdown-it-front-matter "^0.1.2"
-    postcss "^7.0.1"
+    postcss "^7.0.2"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -5347,9 +5361,9 @@ trough@^1.0.0:
   dependencies:
     glob "^6.0.4"
 
-ts-jest@^23.1.1:
-  version "23.1.1"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.1.1.tgz#2f2236d2e0e9e796125bb0d36833da9cc58efc46"
+ts-jest@^23.1.2:
+  version "23.1.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.1.2.tgz#34cd26f3f566924dbd385ad188ae3c3b75757f9e"
   dependencies:
     closest-file-data "^0.1.4"
     fs-extra "6.0.1"


### PR DESCRIPTION
This PR will add math typesetting support with `$inline$` and `$$block$$` syntaxes. This syntax is based on Pandoc and pre-released Marp.

We continue using KaTeX as same as Marp because of the advantage of performance in live-preview. we keep using `markdown-it-katex` too, but the renderer is overridden by own implements. Thus we can use the latest KaTeX for rendering.

The result of rendering on `@marp-team/marp-core` is [this PDF](https://github.com/marp-team/marp-core/files/2260121/example.pdf). (from [Marp example](https://github.com/yhatt/marp/blob/master/example.md#maths-typesetting))

![slide](https://user-images.githubusercontent.com/3993388/43683927-effb3234-98d0-11e8-81ab-01baf016ecea.png)

> Currently this implement is dependent on the change of marp-team/marpit#47.

---

Perhaps some people wonder why a math typesetting is implemented in marp-core rather than Marpit. 

There are a lot of math syntaxes for Markdown and no general consensus (See also [Math in MarkDown](https://github.com/cben/mathdown/wiki/math-in-markdown) survey). So Marpit keeps skinny framework, and it delegates math typesetting support to markdown-it plugin.

### ToDo

- [x] Add tests
- [x] Write document on README.md