### PR TITLE
Improve SCSS typings and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const { html, css } = marp.render('# Hello, marp-core!')
 
 ## Features
 
-_We will only explain features extended in marp-core._ Please refer [@marp-team/marpit](https://github.com/marp-team/marpit) repository to if you want to know the basic feature of Marpit framework.
+_We will only explain features extended in marp-core._ Please refer to [@marp-team/marpit](https://github.com/marp-team/marpit) repository if you want to know the basic feature of Marpit framework.
 
 ### Math typesetting
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,6 @@ module.exports = {
   coverageThreshold: { global: { lines: 95 } },
   transform: {
     '^.*\\.ts$': 'ts-jest',
-    '^.*katex\\.s?css$': '<rootDir>/test/_transformers/katex_css.ts',
     '^.*\\.s?css$': '<rootDir>/test/_transformers/css.ts',
   },
   testRegex: '(/(test|__tests__)/(?!_).*|(\\.|/)(test|spec))\\.[jt]s$',

--- a/src/markdown/__mocks__/katex.scss
+++ b/src/markdown/__mocks__/katex.scss
@@ -1,20 +1,12 @@
-const css = `
 @font-face {
   font-family: KaTeX_Mock;
   src: url(fonts/KaTeX_Mock.woff2) format('woff2'),
     url('fonts/KaTeX_Mock.woff') format('woff'),
-    url("fonts/KaTeX_Mock.ttf") format('truetype');
+    url('fonts/KaTeX_Mock.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
 }
 
 .katex {
   display: inline;
-}
-`.trim()
-
-module.exports = {
-  process() {
-    return `module.exports = ${JSON.stringify(css)};`
-  },
 }

--- a/src/markdown/katex.scss.d.ts
+++ b/src/markdown/katex.scss.d.ts
@@ -1,2 +1,0 @@
-declare const katex: string
-export default katex

--- a/src/scss.d.ts
+++ b/src/scss.d.ts
@@ -1,0 +1,4 @@
+declare module '*.scss' {
+  const scss: string
+  export default scss
+}

--- a/test/_transformers/katex_css.ts
+++ b/test/_transformers/katex_css.ts
@@ -14,7 +14,7 @@ const css = `
 `.trim()
 
 module.exports = {
-  process(src) {
+  process() {
     return `module.exports = ${JSON.stringify(css)};`
   },
 }

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -4,6 +4,8 @@ import postcss from 'postcss'
 import context from './_helpers/context'
 import { Marp, MarpOptions } from '../src/marp'
 
+jest.mock('../src/markdown/katex.scss')
+
 describe('Marp', () => {
   const marp = (opts?: MarpOptions): Marp => new Marp(opts)
 
@@ -159,7 +161,7 @@ describe('Marp', () => {
           return checkWebFont(
             'url(fonts/KaTeX_Mock.woff2)',
             "url('fonts/KaTeX_Mock.woff')",
-            'url("fonts/KaTeX_Mock.ttf")'
+            "url('fonts/KaTeX_Mock.ttf')"
           ).process(css, { from: undefined })
         })
       })

--- a/themes/default.scss.d.ts
+++ b/themes/default.scss.d.ts
@@ -1,2 +1,0 @@
-declare const theme: string
-export default theme

--- a/themes/gaia.scss.d.ts
+++ b/themes/gaia.scss.d.ts
@@ -1,2 +1,0 @@
-declare const theme: string
-export default theme


### PR DESCRIPTION
- Use TypeScript's wildcard module declaration.
- Use Jest's manual mocks instead of custom transformer.