### PR TITLE
Add types script to output TypeScript declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 lib/
 tmp/
+types/
 
 ########## gitignore.io ##########
 # Created by https://www.gitignore.io/api/node,windows,macos,linux,sublimetext,emacs,vim,visualstudiocode

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 coverage/
 lib/
+types/
 node_modules
 package.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+.git/
 coverage/
 lib/
 types/

--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "@marp-team/marp-core",
   "version": "0.0.0",
   "description": "The core of Marp tools",
-  "main": "lib/marp.js",
-  "types": "types/marp.d.ts",
-  "repository": "https://github.com/marp-team/marp-core",
+  "license": "MIT",
   "author": {
     "name": "Marp team",
     "url": "https://github.com/marp-team"
@@ -15,10 +13,16 @@
       "url": "https://github.com/yhatt"
     }
   ],
-  "license": "MIT",
-  "publishConfig": {
-    "access": "public"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marp-team/marp-core"
   },
+  "main": "lib/marp.js",
+  "types": "types/marp.d.ts",
+  "files": [
+    "lib/",
+    "types/marp.d.ts"
+  ],
   "scripts": {
     "build": "yarn --silent clean && rollup -c",
     "check-ts": "tsc --noEmit",
@@ -70,5 +74,8 @@
     "markdown-it-emoji": "^1.4.0",
     "markdown-it-katex": "^2.0.3",
     "postcss": "^7.0.2"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "The core of Marp tools",
   "main": "lib/marp.js",
+  "types": "types/marp.d.ts",
   "repository": "https://github.com/marp-team/marp-core",
   "author": {
     "name": "Marp team",
@@ -28,6 +29,7 @@
     "lint:ts": "tslint \"{src,test}/**/*.ts\"",
     "lint:css": "stylelint \"themes/**/*.{css,scss}\"",
     "test": "jest",
+    "types": "rimraf types && tsc --declaration --emitDeclarationOnly --outDir types",
     "watch": "rollup -w -c"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds `types` npm script to ouput TypeScript declarations.

`marp-core` will be used in the other marp-team packages such as [marp-cli](https://github.com/marp-team/marp-cli), but the type definition will lost by packaging with rollup.

Running `yarn types` will generate `types/*.d.ts` by `tsc` with `--emitDeclarationOnly` flag that has been supported from TypeScript 2.8. We will include `types/marp.d.ts` to `types` and `files` field of `package.json` for using the declaration of `Marp` class.

After than merge, we are going to prepare scripts about publishing to npm such as `version` and `prepack`.