### PR TITLE
Reduce bundle size by stopping to resolve dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Reduce bundle size by stopping to resolve dependencies ([#15](https://github.com/marp-team/marp-core/pull/15))
+
 ## v0.0.1 - 2018-08-10
 
 - Initial release.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ import pkg from './package.json'
 
 export default [
   {
-    external: ['@marp-team/marpit', 'postcss'],
+    external: Object.keys(pkg.dependencies),
     input: `src/${path.basename(pkg.main, '.js')}.ts`,
     output: {
       file: pkg.main,

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -1,7 +1,7 @@
 /* tslint:disable: import-name */
 import { Marpit, MarpitOptions, ThemeSetPackOptions } from '@marp-team/marpit'
 import highlightjs from 'highlight.js'
-import katexPackage from 'katex/package.json'
+import { version } from 'katex/package.json'
 import markdownItEmoji from 'markdown-it-emoji'
 import { markdownItPlugin as mathMD, css as mathCSS } from './markdown/math'
 import defaultTheme from '../themes/default.scss'
@@ -84,9 +84,9 @@ export class Marp extends Marpit {
 
     if (math && this.renderedMath) {
       // By default, we use KaTeX web fonts through CDN.
-      let path: string | undefined = `https://cdn.jsdelivr.net/npm/katex@${
-        katexPackage.version
-      }/dist/fonts/`
+      let path:
+        | string
+        | undefined = `https://cdn.jsdelivr.net/npm/katex@${version}/dist/fonts/`
 
       if (typeof math === 'object') {
         path = math.katexFontPath === false ? undefined : math.katexFontPath

--- a/src/scss.d.ts
+++ b/src/scss.d.ts
@@ -1,4 +1,0 @@
-declare module '*.scss' {
-  const scss: string
-  export default scss
-}

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,0 +1,8 @@
+declare module '*.scss' {
+  const scss: string
+  export default scss
+}
+
+declare module 'katex/package.json' {
+  export const version: string
+}


### PR DESCRIPTION
We will improve rollup configuration to stop resolving `dependencies` packages.

A marp-core's first release had very huge bundle size over than 1MB. It has bundled external plugins such as markdown-it plugins and KaTeX.

This repo is targeted to Node environment, and not browser. Thus dependent packages should be installed to `node_modules` by using `npm install` or `yarn install`.

On the other hand, we improve to work rollup's tree shaking on `katex/package.json`. marp-core will bundle only necessary values.