### PR TITLE
Support fitting header

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,10 +1,11 @@
 let ready = false
 
-function fit() {
+function fitting(): void {
   Array.from(
-    document.querySelectorAll('svg[data-marp-fitting-header="svg"]'),
-    element => {
-      const svg = element as SVGElement
+    document.querySelectorAll<HTMLElement>(
+      'svg[data-marp-fitting-header="svg"]'
+    ),
+    svg => {
       const foreignObject = svg.firstChild as SVGForeignObjectElement
       const container = foreignObject.firstChild as HTMLSpanElement
       const { scrollWidth, scrollHeight } = container
@@ -17,19 +18,16 @@ function fit() {
 
       if (svg.getAttribute('viewBox') !== viewBox) {
         svg.setAttribute('viewBox', viewBox)
-
-        // Reflow forcely (CSS reflow would not trigger in Firefox)
-        svg.style.overflow = 'hidden'
-        setTimeout(() => (svg.style.overflow = 'visible'), 0)
+        svg.classList.toggle('__reflow__') // for incremental update
       }
     }
   )
-  window.requestAnimationFrame(fit)
+  window.requestAnimationFrame(fitting)
 }
 
 export function browser(): void {
   if (ready) return
   ready = true
 
-  window.requestAnimationFrame(fit)
+  fitting()
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,35 @@
+let ready = false
+
+function fit() {
+  Array.from(
+    document.querySelectorAll('svg[data-marp-fitting-header="svg"]'),
+    element => {
+      const svg = element as SVGElement
+      const foreignObject = svg.firstChild as SVGForeignObjectElement
+      const container = foreignObject.firstChild as HTMLSpanElement
+      const { scrollWidth, scrollHeight } = container
+      const w = Math.max(scrollWidth, 1)
+      const h = Math.max(scrollHeight, 1)
+      const viewBox = `0 0 ${w} ${h}`
+
+      foreignObject.setAttribute('width', `${w}`)
+      foreignObject.setAttribute('height', `${h}`)
+
+      if (svg.getAttribute('viewBox') !== viewBox) {
+        svg.setAttribute('viewBox', viewBox)
+
+        // Reflow forcely (CSS reflow would not trigger in Firefox)
+        svg.style.overflow = 'hidden'
+        setTimeout(() => (svg.style.overflow = 'visible'), 0)
+      }
+    }
+  )
+  window.requestAnimationFrame(fit)
+}
+
+export function browser(): void {
+  if (ready) return
+  ready = true
+
+  window.requestAnimationFrame(fit)
+}

--- a/src/markdown/fitting_header.ts
+++ b/src/markdown/fitting_header.ts
@@ -42,6 +42,9 @@ export const css = `
 svg[data-marp-fitting-header="svg"] {
   display: block;
 }
+svg[data-marp-fitting-header="svg"].__reflow__ {
+  content: '';
+}
 [data-marp-fitting-header-svg-content] {
   display: table;
   white-space: nowrap;

--- a/src/markdown/fitting_header.ts
+++ b/src/markdown/fitting_header.ts
@@ -1,9 +1,6 @@
 import Token from 'markdown-it/lib/token'
 
-export default function fittingHeaderPlugin(
-  md,
-  opts: { inlineSVG: boolean }
-): void {
+export function markdownItPlugin(md, opts: { inlineSVG: boolean }): void {
   md.core.ruler.after('inline', 'marp_fitting_header', state => {
     let target = undefined
 
@@ -40,3 +37,15 @@ export default function fittingHeaderPlugin(
     }
   })
 }
+
+export const css = `
+svg[data-marp-fitting-header="svg"] {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+[data-marp-fitting-header-svg-content] {
+  display: table;
+  white-space: nowrap;
+}
+`.trim()

--- a/src/markdown/fitting_header.ts
+++ b/src/markdown/fitting_header.ts
@@ -1,5 +1,4 @@
 import Token from 'markdown-it/lib/token'
-import { open } from 'fs'
 
 export default function fittingHeaderPlugin(
   md,
@@ -33,10 +32,10 @@ export default function fittingHeaderPlugin(
     })
 
     if (opts.inlineSVG) {
-      md.renderer.rules.marp_fitting_header_open = (): string =>
+      md.renderer.rules.marp_fitting_header_open = () =>
         '<svg data-marp-fitting-header="svg"><foreignObject><span data-marp-fitting-header-svg-content>'
 
-      md.renderer.rules.marp_fitting_header_close = (): string =>
+      md.renderer.rules.marp_fitting_header_close = () =>
         '</span></foreignObject></svg>'
     }
   })

--- a/src/markdown/fitting_header.ts
+++ b/src/markdown/fitting_header.ts
@@ -46,4 +46,7 @@ svg[data-marp-fitting-header="svg"] {
   display: table;
   white-space: nowrap;
 }
+[data-marp-fitting-header-svg-content] [data-marpit-emoji] {
+  filter: none;
+}
 `.trim()

--- a/src/markdown/fitting_header.ts
+++ b/src/markdown/fitting_header.ts
@@ -41,8 +41,6 @@ export function markdownItPlugin(md, opts: { inlineSVG: boolean }): void {
 export const css = `
 svg[data-marp-fitting-header="svg"] {
   display: block;
-  width: 100%;
-  height: auto;
 }
 [data-marp-fitting-header-svg-content] {
   display: table;

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -1,4 +1,3 @@
-/* tslint:disable: import-name */
 import { Marpit, MarpitOptions, ThemeSetPackOptions } from '@marp-team/marpit'
 import highlightjs from 'highlight.js'
 import { version } from 'katex/package.json'

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -3,6 +3,7 @@ import { Marpit, MarpitOptions, ThemeSetPackOptions } from '@marp-team/marpit'
 import highlightjs from 'highlight.js'
 import { version } from 'katex/package.json'
 import markdownItEmoji from 'markdown-it-emoji'
+import fittingHeaderPlugin from './markdown/fitting_header'
 import { markdownItPlugin as mathMD, css as mathCSS } from './markdown/math'
 import defaultTheme from '../themes/default.scss'
 import gaiaTheme from '../themes/gaia.scss'
@@ -49,14 +50,14 @@ export class Marp extends Marpit {
   applyMarkdownItPlugins(md = this.markdown) {
     super.applyMarkdownItPlugins(md)
 
+    const { inlineSVG, math } = this.options
+
     // Emoji shorthand
     md.use(markdownItEmoji, { shortcuts: {} })
     md.renderer.rules.emoji = (token, idx) =>
       `<span data-marpit-emoji>${token[idx].content}</span>`
 
     // Math typesetting
-    const { math } = this.options
-
     if (math) {
       const opts =
         typeof math === 'object' && typeof math.katexOption === 'object'
@@ -67,6 +68,9 @@ export class Marp extends Marpit {
         this.renderedMath = isRendered
       })
     }
+
+    // Fitting header
+    md.use(fittingHeaderPlugin, { inlineSVG })
   }
 
   highlighter(code: string, lang: string): string {

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -2,7 +2,11 @@ import { Marpit, MarpitOptions, ThemeSetPackOptions } from '@marp-team/marpit'
 import highlightjs from 'highlight.js'
 import { version } from 'katex/package.json'
 import markdownItEmoji from 'markdown-it-emoji'
-import fittingHeaderPlugin from './markdown/fitting_header'
+import { browser } from './browser'
+import {
+  markdownItPlugin as fittingHeaderMD,
+  css as fittingHeaderCSS,
+} from './markdown/fitting_header'
 import { markdownItPlugin as mathMD, css as mathCSS } from './markdown/math'
 import defaultTheme from '../themes/default.scss'
 import gaiaTheme from '../themes/gaia.scss'
@@ -69,7 +73,7 @@ export class Marp extends Marpit {
     }
 
     // Fitting header
-    md.use(fittingHeaderPlugin, { inlineSVG })
+    md.use(fittingHeaderMD, { inlineSVG })
   }
 
   highlighter(code: string, lang: string): string {
@@ -83,7 +87,10 @@ export class Marp extends Marpit {
 
   protected themeSetPackOptions(): ThemeSetPackOptions {
     const base = { ...super.themeSetPackOptions() }
+    const prependCSS = css => (base.before = `${css}\n${base.before || ''}`)
     const { math } = this.options
+
+    prependCSS(fittingHeaderCSS)
 
     if (math && this.renderedMath) {
       // By default, we use KaTeX web fonts through CDN.
@@ -96,10 +103,18 @@ export class Marp extends Marpit {
       }
 
       // Add KaTeX css
-      base.before = `${mathCSS(path)}\n${base.before || ''}`
+      prependCSS(mathCSS(path))
     }
 
     return base
+  }
+
+  static ready() {
+    if (typeof window === 'undefined') {
+      throw new Error('Marp.ready() is only valid in browser context.')
+    }
+
+    browser()
   }
 }
 

--- a/themes/default.scss
+++ b/themes/default.scss
@@ -61,6 +61,10 @@ footer {
   bottom: 21px;
 }
 
+svg[data-marp-fitting-header='svg'] {
+  max-height: 563px; // Slide height - padding * 2
+}
+
 section {
   @extend .markdown-body;
 
@@ -70,8 +74,10 @@ section {
   flex-direction: column;
   flex-wrap: nowrap;
   font-size: 29px;
+  height: 720px;
   justify-content: center;
   padding: 78.5px;
+  width: 1280px;
 
   > *:last-child,
   &[data-footer] > :nth-last-child(2) {

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -180,6 +180,10 @@ table {
   }
 }
 
+svg[data-marp-fitting-header='svg'] {
+  max-height: 580px; // Slide height - padding * 2
+}
+
 section {
   background-image: linear-gradient(
     135deg,
@@ -191,9 +195,11 @@ section {
   font-size: 35px;
   font-family: 'Lato', 'Avenir Next', 'Avenir', 'Trebuchet MS', 'Segoe UI',
     sans-serif;
+  height: 720px;
   line-height: 1.35;
   letter-spacing: 1.25px;
   padding: 70px;
+  width: 1280px;
 
   > *:first-child,
   > header:first-child + * {
@@ -216,6 +222,10 @@ section {
     flex-wrap: nowrap;
     justify-content: center;
 
+    svg[data-marp-fitting-header='svg'] {
+      margin: 0 auto;
+    }
+
     h1,
     h2,
     h3,
@@ -235,6 +245,10 @@ section {
       > h6,
       > p {
         text-align: left;
+      }
+
+      svg[data-marp-fitting-header='svg'] {
+        margin: 0;
       }
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "lib": ["es2016"],
+    "lib": ["es2016", "dom"],
     "module": "commonjs",
     "noImplicitAny": false,
     "outDir": "lib",

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": ["tslint-config-airbnb", "tslint-config-prettier"],
   "rules": {
-    "no-boolean-literal-compare": false
+    "no-boolean-literal-compare": false,
+    "import-name": false
   }
 }


### PR DESCRIPTION
This PR will support a fitting header by `<!--fit-->` HTML comment on headings.

We are planning that marp-core would implement aggressive features than Marpit, and this feature is one of them.

## Syntax

The fitting header is similar to [Deckset's `[fit]` keyword](https://docs.decksetapp.com/English.lproj/Formatting/01-headings.html), but we use HTML comment to keep a nice rendering on general Markdown document without seeing an unsightly keyword.

![fitting-header](https://user-images.githubusercontent.com/3993388/44138364-a4dacb80-a0ae-11e8-9d5c-8eeaa45a4ed8.png)

This syntax was come true by [@marp-team/marpit `v0.0.11`](https://github.com/marp-team/marpit/releases/tag/v0.0.11) release's inline comment support. Refer to marp-team/marpit#52.

## Limitation

*A first-class support is available __only__ in Marpit's [inline SVG mode](https://github.com/marp-team/marpit#inline-svg-slide-experimental)* (`inlineSVG: true`) for a low-cost implementation about resizing. It works nicely with any inline contents includes image.

![realtime](https://user-images.githubusercontent.com/3993388/44140182-43172dde-a0b4-11e8-983d-ba2b925839b2.gif)

In `inlineSVG: false`, we would apply DOM structure of fitting header but not provide any fitting actions. You can apply a third-party module like [Fitty](https://github.com/rikschennink/fitty) if you want.

```javascript
fitty('[data-marp-fitting-header="plain"]')
```

## `Marp.ready()`

This feature requires always monitoring DOM element to support fitting a size of any inline contents because a real-time previewing is still a key feature of Marp.

So we add `Marp.ready()` static method to trigger the monitoring on browser context.

## Known issues

- If you are using an incremental update to render Markdown (e.g. [yhatt/markdown-it-incremental-dom](https://github.com/yhatt/markdown-it-incremental-dom)), The heading elements might not trigger a [browser reflow](https://developers.google.com/speed/docs/insights/browser-reflow) on Firefox. The toggle of `__reflow__` class is a bit ugly workaround.  
　
- Any emoji would lose on printed PDF when these are included in fitting header even if Marpit option is defined as `printable: true`. We can avoid this issue by disabling a printable hack in fitting header, but `Segoe UI Emoji` would not color emoji on Windows Chrome.

## ToDo

- [ ] Add tests
- [ ] Refactor code