### PR TITLE
Aggressive emoji support with twemoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Upgrade dependencies to latest ([#16](https://github.com/marp-team/marp-core/pull/16))
 - Support fitting header ([#17](https://github.com/marp-team/marp-core/pull/17))
 - Add `uncover` theme ([#18](https://github.com/marp-team/marp-core/pull/18))
+- Add emoji support with twemoji ([#19](https://github.com/marp-team/marp-core/pull/19))
 
 ## v0.0.1 - 2018-08-10
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
 _We will only explain features extended in marp-core._ Please refer to [@marp-team/marpit](https://github.com/marp-team/marpit) repository if you want to know the basic feature of Marpit framework.
 
+### Marp Markdown
+
+Marp Markdown is based on [Marpit](https://github.com/marp-team/marpit) and [CommonMark](https://commonmark.org/), and there are these additional features:
+
+- **Marpit**
+  - Enable [inline SVG mode](https://github.com/marp-team/marpit#inline-svg-slide-experimental) and lazy YAML parsing by default.
+- **CommonMark**
+  - For security reason, HTML tag is disabled by default.
+  - [Support table syntax based on GitHub Flavored Markdown.](https://help.github.com/articles/organizing-information-with-tables/)
+  - Line breaks in paragraph will convert to `<br>` tag.
+  - Auto convert URL like text into hyperlink.
+
+### Emoji support
+
+Emoji shortcode (like `:smile:`) and Unicode emoji 😄 will convert into the SVG vector image provided by [twemoji](https://github.com/twitter/twemoji) <img src="https://twemoji.maxcdn.com/2/svg/1f604.svg" alt="😄" width="16" height="16" />. It could render emoji with high resolution.
+
 ### Math typesetting
 
 We have [Pandoc's Markdown style](https://pandoc.org/MANUAL.html#math) math typesetting support by [KaTeX](https://khan.github.io/KaTeX/). Surround your formula by `$...$` to render math as inline, and `$$...$$` to render as block.
@@ -91,16 +107,26 @@ This syntax is similar to [Deckset's `[fit]` keyword](https://docs.decksetapp.co
 
 You can customize a behavior of Marp parser by passing an options object to the constructor. You can also pass together with [Marpit constructor options](https://marpit.netlify.com/marpit#Marpit).
 
+> :information_source: [Marpit's `markdown` option](https://github.com/marp-team/marpit/blob/6cec8177b1c296c6df4ec8c917e7c780940ad3bf/src/marpit.js#L58-L59) is accepted only object options because of always using CommonMark.
+
 ```javascript
 const marp = new Marp({
   // marp-core constructor options
-  html: false,
+  html: true,
+  emoji: {
+    shortcode: true,
+    unicode: false,
+    twemojiBase: '/resources/twemoji/',
+  },
   math: {
     katexFontPath: '/resources/fonts/',
   },
 
-  // Marpit constructor options
-  inlineSVG: true,
+  // It can be included Marpit constructor options
+  lazyYAML: false,
+  markdown: {
+    breaks: false,
+  },
 })
 ```
 
@@ -110,6 +136,29 @@ Setting whether to render raw HTML in Markdown. The default value is **`false`**
 
 Even if you are setting `false`, `<!-- HTML comment -->` is always parsed by Marpit for directives. When you are not disabled [Marpit's `inlineStyle` option](https://marpit.netlify.com/marpit#Marpit) by `false`, `<style>` tags are parsed too for tweaking theme style.
 
+> :information_source: `html` flag in `markdown` option cannot use because of overridden by this.
+
+### `emoji`: _`object`_
+
+Setting about emoji conversions.
+
+- **`shortcode`**: _`boolean` | `"twemoji"`_
+
+  - By setting `false`, it does not convert any emoji shortcodes.
+  - By setting `true`, it converts emoji shortcodes into Unicode emoji. `:dog:` → 🐶
+  - By setting `"twemoji"` string, it converts into twemoji vector image. `:dog:` → <img src="https://twemoji.maxcdn.com/2/svg/1f436.svg" alt="🐶" width="16" height="16" valign="middle" /> _(default)_
+
+- **`unicode`**: _`boolean` | `"twemoji"`_
+
+  - It can convert Unicode emoji into twemoji when setting `"twemoji"`. 🐶 → <img src="https://twemoji.maxcdn.com/2/svg/1f436.svg" alt="🐶" width="16" height="16" valign="middle" /> _(default)_
+  - If you not want this aggressive conversion, please set `false`.
+
+- **`twemojiBase`**: _`string`_
+
+  - It is corresponded to [twemoji's `base` option](https://github.com/twitter/twemoji#object-as-parameter). By default, marp-core will use online emoji images [through MaxCDN (twemoji's default)](https://github.com/twitter/twemoji#cdn-support).
+
+> **For developers:** When you setting `unicode` option as `true`, Markdown parser will convert Unicode emoji into tokens internally. The rendering result is same as in `true`.
+
 ### `math`: _`boolean` | `object`_
 
 Enable or disable [math typesetting](#math-typesetting) syntax. The default value is `true`.
@@ -117,8 +166,11 @@ Enable or disable [math typesetting](#math-typesetting) syntax. The default valu
 You can modify KaTeX further settings by passing an object of sub-options.
 
 - **`katexOption`**: _`object`_
+
   - The options passing to KaTeX. Please refer to [KaTeX document](https://khan.github.io/KaTeX/docs/options.html).
+
 - **`katexFontPath`**: _`string` | `false`_
+
   - By default, marp-core will use [online web-font resources through jsDelivr CDN](https://cdn.jsdelivr.net/npm/katex@latest/dist/fonts/). You have to set path to fonts directory if you want to use local resources. If you set `false`, we will not manipulate the path (Use KaTeX's original path: `fonts/KaTeX_***-***.woff2`).
 
 <!-- ## [Work in progress] Themes -->

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "uglify-es": "^3.3.9"
   },
   "dependencies": {
-    "@marp-team/marpit": "^0.0.11",
+    "@marp-team/marpit": "^0.0.12",
     "emoji-regex": "^7.0.0",
     "highlight.js": "^9.12.0",
     "katex": "^0.10.0-beta",

--- a/package.json
+++ b/package.json
@@ -78,12 +78,14 @@
   },
   "dependencies": {
     "@marp-team/marpit": "^0.0.11",
+    "emoji-regex": "^7.0.0",
     "highlight.js": "^9.12.0",
     "katex": "^0.10.0-beta",
     "markdown-it": "^8.4.2",
     "markdown-it-emoji": "^1.4.0",
     "markdown-it-katex": "^2.0.3",
-    "postcss": "^7.0.2"
+    "postcss": "^7.0.2",
+    "twemoji": "^11.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -1,14 +1,96 @@
+import emojiRegex from 'emoji-regex'
+import Token from 'markdown-it/lib/token'
 import markdownItEmoji from 'markdown-it-emoji'
+import twemoji from 'twemoji'
+import twemojiCSS from './twemoji.scss'
 
 export interface EmojiOptions {
   shortcode?: boolean | 'twemoji'
-  unicode?: true | 'twemoji'
+  twemojiBase?: string
+  unicode?: boolean | 'twemoji'
 }
 
-export function css(opts: EmojiOptions): string | undefined {
-  return undefined
-}
+const regexForSplit = new RegExp(`(${emojiRegex().source})`, 'g')
+
+export const css = (opts: EmojiOptions) =>
+  opts.shortcode === 'twemoji' || opts.unicode === 'twemoji'
+    ? twemojiCSS
+    : undefined
 
 export function markdown(md, opts: EmojiOptions): void {
-  if (opts.shortcode) md.use(markdownItEmoji, { shortcuts: {} })
+  const twemojiParse = (content: string): string =>
+    twemoji
+      .parse(content, {
+        base: opts.twemojiBase,
+        className: '__placeholder__',
+        ext: '.svg',
+        size: 'svg',
+      })
+      .replace('class="__placeholder__"', 'data-marp-twemoji')
+
+  const twemojiRenderer = (token: any[], idx: number): string =>
+    twemojiParse(token[idx].content)
+
+  if (opts.shortcode) {
+    md.use(markdownItEmoji, { shortcuts: {} })
+    if (opts.shortcode === 'twemoji') md.renderer.rules.emoji = twemojiRenderer
+  }
+
+  if (opts.unicode) {
+    md.core.ruler.after('inline', 'marp_unicode_emoji', ({ tokens }) => {
+      tokens.forEach(token => {
+        if (token.type !== 'inline') return
+
+        token.children = token.children.reduce((arr, t) => {
+          if (t.type !== 'text') return [...arr, t]
+
+          return [
+            ...arr,
+            ...t.content.split(regexForSplit).reduce(
+              (splitedArr, text, idx) =>
+                text.length === 0
+                  ? splitedArr
+                  : [
+                      ...splitedArr,
+                      Object.assign(new Token(), {
+                        ...t,
+                        content: text,
+                        type: idx % 2 ? 'unicode_emoji' : 'text',
+                      }),
+                    ],
+              []
+            ),
+          ]
+        }, [])
+      })
+    })
+
+    md.renderer.rules.unicode_emoji = (token: any[], idx: number): string =>
+      token[idx].content
+
+    const { code_block, code_inline, fence } = md.renderer.rules
+
+    if (opts.unicode === 'twemoji') {
+      const wrap = text =>
+        text
+          .split(/(<[^>]*>)/g)
+          .reduce(
+            (ret, part, idx) =>
+              `${ret}${
+                idx % 2
+                  ? part
+                  : part.replace(regexForSplit, ([emoji]) =>
+                      twemojiParse(emoji)
+                    )
+              }`,
+            ''
+          )
+
+      md.renderer.rules.unicode_emoji = twemojiRenderer
+
+      md.renderer.rules.code_inline = (...args) => wrap(code_inline(...args))
+      md.renderer.rules.code_block = (...args) => wrap(code_block(...args))
+      md.renderer.rules.fence = (...args) => wrap(fence(...args))
+    }
+  }
 }

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -1,0 +1,14 @@
+import markdownItEmoji from 'markdown-it-emoji'
+
+export interface EmojiOptions {
+  shortcode?: boolean | 'twemoji'
+  unicode?: true | 'twemoji'
+}
+
+export function css(opts: EmojiOptions): string | undefined {
+  return undefined
+}
+
+export function markdown(md, opts: EmojiOptions): void {
+  if (opts.shortcode) md.use(markdownItEmoji, { shortcuts: {} })
+}

--- a/src/emoji/twemoji.scss
+++ b/src/emoji/twemoji.scss
@@ -1,0 +1,7 @@
+img[data-marp-twemoji] {
+  background: transparent;
+  height: 1em;
+  margin: 0 0.05em 0 0.1em;
+  vertical-align: -0.1em;
+  width: 1em;
+}

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -28,9 +28,10 @@ export class Marp extends Marpit {
   private renderedMath: boolean = false
 
   constructor(opts: MarpOptions = {}) {
-    super({
+    super(<MarpOptions>{
       emoji: {
         shortcode: true,
+        twemojiBase: undefined,
         unicode: true,
         ...(opts.emoji || {}),
       },
@@ -48,7 +49,7 @@ export class Marp extends Marpit {
       ],
       math: true,
       ...opts,
-    } as MarpitOptions)
+    })
 
     // Enable table
     this.markdown.enable(['table', 'linkify'])

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -32,7 +32,7 @@ export class Marp extends Marpit {
       emoji: {
         shortcode: true,
         twemojiBase: undefined,
-        unicode: true,
+        unicode: false,
         ...(opts.emoji || {}),
       },
       inlineSVG: true,

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -14,6 +14,7 @@ const marpObservedSymbol = Symbol('marpObserved')
 export interface MarpOptions extends MarpitOptions {
   emoji?: emojiPlugin.EmojiOptions
   html?: boolean
+  markdown?: object
   math?:
     | boolean
     | {
@@ -31,18 +32,19 @@ export class Marp extends Marpit {
     super(<MarpOptions>{
       inlineSVG: true,
       lazyYAML: true,
+      math: true,
+      ...opts,
       markdown: [
         'commonmark',
         {
           breaks: true,
+          linkify: true,
+          ...(typeof opts.markdown === 'object' ? opts.markdown : {}),
           highlight: (code: string, lang: string) =>
             this.highlighter(code, lang),
           html: opts.html !== undefined ? opts.html : false,
-          linkify: true,
         },
       ],
-      math: true,
-      ...opts,
       emoji: {
         shortcode: 'twemoji',
         twemojiBase: undefined,

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -8,7 +8,6 @@ import * as mathPlugin from './math/math'
 import defaultTheme from '../themes/default.scss'
 import gaiaTheme from '../themes/gaia.scss'
 import uncoverTheme from '../themes/uncover.scss'
-import { css } from './math/math'
 
 const marpObservedSymbol = Symbol('marpObserved')
 

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -29,12 +29,6 @@ export class Marp extends Marpit {
 
   constructor(opts: MarpOptions = {}) {
     super(<MarpOptions>{
-      emoji: {
-        shortcode: true,
-        twemojiBase: undefined,
-        unicode: false,
-        ...(opts.emoji || {}),
-      },
       inlineSVG: true,
       lazyYAML: true,
       markdown: [
@@ -49,6 +43,12 @@ export class Marp extends Marpit {
       ],
       math: true,
       ...opts,
+      emoji: {
+        shortcode: 'twemoji',
+        twemojiBase: undefined,
+        unicode: 'twemoji',
+        ...(opts.emoji || {}),
+      },
     })
 
     // Enable table

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -35,68 +35,36 @@ describe('Marp', () => {
 
   describe('emoji option', () => {
     describe('shortcode option', () => {
-      it('converts emoji shorthand to unicode emoji by default', () => {
-        const { html, css } = marp().render('# emoji:heart:\n\n## emoji❤️')
+      it('converts emoji shorthand to twemoji image by default', () => {
+        const { html, css } = marp().render('# :heart:')
         const $ = cheerio.load(html)
 
-        expect($('h1').html()).toBe($('h2').html())
-        expect(css).not.toContain('img[data-marp-twemoji]')
+        expect($('h1 > img[data-marp-twemoji][alt="❤️"]')).toHaveLength(1)
+        expect(css).toContain('img[data-marp-twemoji]')
+      })
+
+      context('with true', () => {
+        const emoji: EmojiOptions = { shortcode: true }
+
+        it('converts emoji shorthand to unicode emoji', () => {
+          const $ = cheerio.load(marp({ emoji }).render('# :heart:').html)
+          expect($('h1').html()).toBe('&#x2764;&#xFE0F;')
+        })
       })
 
       context('with false', () => {
         const emoji: EmojiOptions = { shortcode: false }
 
         it('does not convert emoji shorthand', () => {
-          const { html, css } = marp({ emoji }).render('# :heart:')
-          const $ = cheerio.load(html)
-
+          const $ = cheerio.load(marp({ emoji }).render('# :heart:').html)
           expect($('h1').html()).toBe(':heart:')
-          expect(css).not.toContain('img[data-marp-twemoji]')
-        })
-      })
-
-      context('with twemoji', () => {
-        const emoji: EmojiOptions = { shortcode: 'twemoji' }
-
-        it('converts emoji shorthand to twemoji image', () => {
-          const { html, css } = marp({ emoji }).render('# :heart:')
-          const $ = cheerio.load(html)
-
-          expect($('h1 > img[data-marp-twemoji][alt="❤️"]')).toHaveLength(1)
-          expect(css).toContain('img[data-marp-twemoji]')
         })
       })
     })
 
     describe('unicode option', () => {
-      it('does not inject unicode emoji renderer by default', () =>
-        expect(marp().markdown.renderer.rules.unicode_emoji).toBeUndefined())
-
-      it('does not convert unicode emoji', () => {
-        const { html, css } = marp().render('# 👍')
-
-        expect(html).toContain('<h1>👍</h1>')
-        expect(css).not.toContain('img[data-marp-twemoji]')
-      })
-
-      context('with true', () => {
-        const emoji: EmojiOptions = { unicode: true }
-        const instance = marp({ emoji })
-
-        it('injects unicode emoji renderer', () =>
-          expect(instance.markdown.renderer.rules.unicode_emoji).toBeTruthy())
-
-        it('does not convert unicode emoji', () => {
-          const { html, css } = instance.render('# 👍')
-
-          expect(html).toContain('<h1>👍</h1>')
-          expect(css).not.toContain('img[data-marp-twemoji]')
-        })
-      })
-
-      context('with twemoji', () => {
-        const emoji: EmojiOptions = { unicode: 'twemoji' }
-        const instance = marp({ emoji })
+      context('with twemoji (by default)', () => {
+        const instance = marp()
 
         it('converts unicode emoji to twemoji image', () => {
           const { html, css } = instance.render('# 👍')
@@ -131,11 +99,32 @@ describe('Marp', () => {
           expect($emoji('h1 > img[data-marp-twemoji]')).toHaveLength(1)
         })
       })
+
+      context('with false', () => {
+        const emoji: EmojiOptions = { unicode: false }
+        const instance = marp({ emoji })
+
+        it('does not inject unicode emoji renderer', () =>
+          expect(instance.markdown.renderer.rules.unicode_emoji).toBeFalsy())
+
+        it('does not convert unicode emoji', () =>
+          expect(instance.render('# 👍').html).toContain('<h1>👍</h1>'))
+      })
+
+      context('with true', () => {
+        const emoji: EmojiOptions = { unicode: true }
+        const instance = marp({ emoji })
+
+        it('injects unicode emoji renderer', () =>
+          expect(instance.markdown.renderer.rules.unicode_emoji).toBeTruthy())
+
+        it('does not convert unicode emoji', () =>
+          expect(instance.render('# 👍').html).toContain('<h1>👍</h1>'))
+      })
     })
 
     describe('twemojiBase option', () => {
-      const instance = (opts: EmojiOptions = {}) =>
-        new Marp({ emoji: { shortcode: 'twemoji', ...opts } })
+      const instance = (emoji: EmojiOptions = {}) => new Marp({ emoji })
 
       it('uses twemoji CDN by default', () => {
         const $ = cheerio.load(instance().render('# :ok_hand:').html)

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -36,7 +36,6 @@ describe('Marp', () => {
         marp().markdown.render('# emoji:heart:\n\n## emoji❤️')
       )
       expect($('h1').html()).toBe($('h2').html())
-      expect($('h1 > span[data-marpit-emoji]')).toHaveLength(1)
     })
   })
 

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -132,6 +132,26 @@ describe('Marp', () => {
         })
       })
     })
+
+    describe('twemojiBase option', () => {
+      const instance = (opts: EmojiOptions = {}) =>
+        new Marp({ emoji: { shortcode: 'twemoji', ...opts } })
+
+      it('uses twemoji CDN by default', () => {
+        const $ = cheerio.load(instance().render('# :ok_hand:').html)
+        const src = $('h1 > img[data-marp-twemoji]').attr('src')
+
+        expect(src).toBe('https://twemoji.maxcdn.com/2/svg/1f44c.svg')
+      })
+
+      it('uses specified base when twemojiBase option is defined', () => {
+        const marp = instance({ twemojiBase: '/assets/twemoji/' })
+        const $ = cheerio.load(marp.render('# :ok_hand:').html)
+        const src = $('h1 > img[data-marp-twemoji]').attr('src')
+
+        expect(src).toBe('/assets/twemoji/svg/1f44c.svg')
+      })
+    })
   })
 
   describe('html option', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,11 +153,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@marp-team/marpit@^0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.0.11.tgz#46102dba5343722734fe75e8613e5b800ca3cd19"
+"@marp-team/marpit@^0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.0.12.tgz#a4063601dae6f94aadc27f7dce128b3dd0730726"
   dependencies:
-    emoji-regex "^7.0.0"
     js-yaml "^3.12.0"
     lodash.kebabcase "^4.1.1"
     markdown-it "^8.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6016,6 +6016,10 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
+twemoji@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-11.0.1.tgz#e3c115a9795bb26cab6ea48d22821b0a4be08e5b"
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"


### PR DESCRIPTION
This PR will add an aggressive emoji support with [twemoji](https://github.com/twitter/twemoji).

[@marp-team/marpit](https://github.com/marp-team/marpit) has removed unicode emoji support on [v0.0.12](https://github.com/marp-team/marpit/releases/tag/v0.0.12) because of issues in stable Chrome (Refer to marp-team/marpit#53).

However, marp-core should not mutate an exported result by environment's emoji fonts because of supporting on multi-platform including Web. (e.g. Server-side PDF rendering)

So we implement the aggressive Emoji conversion by using [twemoji](https://github.com/twitter/twemoji). It can convert emoji shortcodes and any Unicode emoji to twemoji. Especially Unicode will convert even if it was included in `<code>` elements. (Ported from previous Marpit implementation)

Unlike Marpit's previous printable emoji support, the rendered emoji by twemoji is always colored and would never vanish.

## Aggressive conversion of unicode emoji

```markdown
# Shortcode :arrow_right: :+1::cat::hamburger:

# Unicode ➡️ 😃⚽🔥

---

# <!--fit--> 👪 /w fitting
```

|Disabled|Enabled|
|:---:|:---:|
|![not-colored](https://user-images.githubusercontent.com/3993388/44306529-a4995180-a3cb-11e8-8f3b-649bf84ad172.png)|![twemoji](https://user-images.githubusercontent.com/3993388/44306530-a7944200-a3cb-11e8-8843-964505915fab.png)|

## Options

Some people might disappoint not to be able to use Unicode emoji. Thus we add `emoji` option in Marp constructor. You can customize option if you are using marp-core directly.

We might stop the conversion of Unicode emoji when the stable colored emoji rendering was supported on Chrome in future.