### PR TITLE
Add a separated bundle of Marp.ready() for browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add a separated bundle of `Marp.ready()` for browser ([#21](https://github.com/marp-team/marp-core/pull/21))
+
 ## v0.0.2 - 2018-08-19
 
 - Reduce bundle size by stopping to resolve dependencies ([#15](https://github.com/marp-team/marp-core/pull/15))

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ document.addEventListener('DOMContentLoaded', () => {
 })
 ```
 
+#### Separated bundle
+
+We also provide a separated bundle [`lib/browser.js`](https://cdn.jsdelivr.net/npm/@marp-team/marp-core/lib/browser.js) for browser context. It is useful when you cannot use bundler for the browser, like [@marp-team/marp-cli](https://github.com/marp-team/marp-cli).
+
+Loading `lib/browser.js` will bring the almost same result as running `Marp.ready()`. Thus, you could use it through CDN as below:
+
+```html
+<html>
+<body>
+  <!-- Please insert here rendered HTML by `Marp.render().html`... -->
+  <script defer src="https://cdn.jsdelivr.net/npm/@marp-team/marp-core/lib/browser.js"></script>
+</body>
+</html>
+```
+
 ## Features
 
 _We will only explain features extended in marp-core._ Please refer to [@marp-team/marpit](https://github.com/marp-team/marpit) repository if you want to know the basic feature of Marpit framework.

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,3 @@
+import browser from './src/browser'
+
+browser()

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "https://github.com/marp-team/marp-core"
   },
   "main": "lib/marp.js",
+  "marpBrowser": "lib/browser.js",
   "types": "types/marp.d.ts",
   "files": [
     "lib/",


### PR DESCRIPTION
This PR will add a separated bundle of `Marp.ready()` for browser.

The first Marp family tool [@marp-team/marp-cli](https://github.com/marp-team/marp-cli) has been shiped as super-early release!

A problem is that `Marp.ready()` cannot execute in exported HTML. marp-cli cannot use only `Marp.ready()` from the bundled JS of current core.

Thus, we would bundle JS individually for browser. We added `marpBrowser` key to `package.json`, and marp-cli would read JS from this key.