### PR TITLE
Fix fitting header's size on printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Add a separated bundle of `Marp.ready()` for browser ([#21](https://github.com/marp-team/marp-core/pull/21))
+- Fix fitting header's size on printing ([#22](https://github.com/marp-team/marp-core/pull/22))
 
 ## v0.0.2 - 2018-08-19
 

--- a/src/fitting/fitting.scss
+++ b/src/fitting/fitting.scss
@@ -1,5 +1,7 @@
 svg[data-marp-fitting='svg'] {
   display: block;
+  height: auto;
+  width: 100%;
 }
 
 svg[data-marp-fitting='svg'].__reflow__ {

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -223,8 +223,6 @@ section {
     justify-content: center;
 
     svg[data-marp-fitting='svg'] {
-      margin: 0 auto;
-
       --preserve-aspect-ratio: xMidYMid meet;
     }
 
@@ -250,8 +248,6 @@ section {
       }
 
       svg[data-marp-fitting='svg'] {
-        margin: 0;
-
         --preserve-aspect-ratio: xMinYMin meet;
       }
     }

--- a/themes/uncover.scss
+++ b/themes/uncover.scss
@@ -91,7 +91,6 @@ section {
   }
 
   svg[data-marp-fitting='svg'] {
-    margin: 0 auto;
     max-height: 660px; // Slide height - padding * 2
 
     --preserve-aspect-ratio: xMidYMid meet;


### PR DESCRIPTION
When Marp's fitting header is applied to the exported HTML by [marp-team/marp-cli](https://github.com/marp-team/marp-cli), it will have broken layout on printing.

|[Incorrect fitting](https://github.com/marp-team/marp-core/files/2309084/test_incorrect.pdf)|[Correct fitting](https://github.com/marp-team/marp-core/files/2309086/test_correct.pdf)|
|:---:|:---:|
|![Incorrect](https://user-images.githubusercontent.com/3993388/44446228-11f0f080-a61f-11e8-91fe-0e8ffc6f9b42.png)|![Correct](https://user-images.githubusercontent.com/3993388/44446234-1a492b80-a61f-11e8-8309-c46314d8015e.png)|

This PR will specific the default width and height to fix fitting size on printing.


