### PR TITLE
Auto scaling code block & fence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Support auto scaling of code block and fence ([#23](https://github.com/marp-team/marp-core/pull/23))
+
 ## v0.0.3 - 2018-08-22
 
 - Add a separated bundle of `Marp.ready()` for browser ([#21](https://github.com/marp-team/marp-core/pull/21))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Support auto scaling of code block and fence ([#23](https://github.com/marp-team/marp-core/pull/23))
+- Support auto scaling of code block and fence (for `default` / `gaia` theme) ([#23](https://github.com/marp-team/marp-core/pull/23))
 
 ## v0.0.3 - 2018-08-22
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "uglify-es": "^3.3.9"
   },
   "dependencies": {
-    "@marp-team/marpit": "^0.0.12",
+    "@marp-team/marpit": "^0.0.13",
     "emoji-regex": "^7.0.0",
     "highlight.js": "^9.12.0",
     "katex": "^0.10.0-beta",

--- a/src/fitting/fitting.scss
+++ b/src/fitting/fitting.scss
@@ -14,6 +14,6 @@ svg[data-marp-fitting='svg'].__reflow__ {
   white-space: nowrap;
 }
 
-[data-marp-fitting-svg-content='pre'] {
+[data-marp-fitting-svg-content-wrap] {
   white-space: pre;
 }

--- a/src/fitting/fitting.scss
+++ b/src/fitting/fitting.scss
@@ -13,3 +13,7 @@ svg[data-marp-fitting='svg'].__reflow__ {
   display: table;
   white-space: nowrap;
 }
+
+[data-marp-fitting-svg-content='pre'] {
+  white-space: pre;
+}

--- a/src/fitting/fitting.ts
+++ b/src/fitting/fitting.ts
@@ -8,6 +8,8 @@ export const code = 'data-marp-fitting-code'
 export const svgContentAttr = 'data-marp-fitting-svg-content'
 export const svgContentWrapAttr = 'data-marp-fitting-svg-content-wrap'
 
+export type ThemeResolver = () => string | undefined
+
 function wrapTokensByFittingToken(tokens: any[]): any[] {
   const open = new Token('marp_fitting_open', 'span', 1)
   open.attrSet(attr, 'plain')
@@ -16,16 +18,14 @@ function wrapTokensByFittingToken(tokens: any[]): any[] {
 }
 
 // Wrap code block and fence renderer by fitting elements.
-function fittingCode(md, marp: Marp): void {
+function fittingCode(md, marp: Marp, themeResolver: ThemeResolver): void {
   const { code_block, fence } = md.renderer.rules
 
   const codeMatcher = /^(<pre[^>]*?><code[^>]*?>)([\s\S]*)(<\/code><\/pre>\n*)$/
 
   const replacedRenderer = func => (...args) => {
     const rendered: string = func(...args)
-
-    const { theme } = marp.lastGlobalDirectives
-    const { fittingCode } = marp.themeSet.getThemeProp(theme, 'meta')
+    const { fittingCode } = marp.themeSet.getThemeProp(themeResolver()!, 'meta')
 
     if (fittingCode === 'false') return rendered
 
@@ -69,9 +69,9 @@ function fittingHeader(md): void {
   })
 }
 
-export function markdown(md, marp: Marp): void {
+export function markdown(md, marp: Marp, themeResolver: ThemeResolver): void {
   md.use(fittingHeader)
-  md.use(fittingCode, marp)
+  md.use(fittingCode, marp, themeResolver)
 
   if (marp.options.inlineSVG) {
     Object.assign(md.renderer.rules, {

--- a/src/fitting/fitting.ts
+++ b/src/fitting/fitting.ts
@@ -15,12 +15,15 @@ function wrapTokensByFittingToken(tokens: any[]): any[] {
   return [open, ...tokens, new Token('marp_fitting_close', 'span', -1)]
 }
 
+// Wrap code block and fence renderer by fitting elements.
 function fittingCode(md, marp: Marp): void {
   const { code_block, fence } = md.renderer.rules
 
   const codeMatcher = /^(<pre[^>]*?><code[^>]*?>)([\s\S]*)(<\/code><\/pre>\n*)$/
+
   const replacedRenderer = func => (...args) => {
     const rendered: string = func(...args)
+
     const { theme } = marp.lastGlobalDirectives
     const { fittingCode } = marp.themeSet.getThemeProp(theme, 'meta')
 
@@ -28,7 +31,12 @@ function fittingCode(md, marp: Marp): void {
 
     return rendered.replace(codeMatcher, (_, start, content, end) => {
       if (marp.options.inlineSVG) {
-        return `${start}<svg ${attr}="svg" ${code}><foreignObject><span ${svgContentAttr}><span ${svgContentWrapAttr}>${content}</span></span></foreignObject></svg>${end}`
+        return [
+          `${start}<svg ${attr}="svg" ${code}><foreignObject>`,
+          `<span ${svgContentAttr}><span ${svgContentWrapAttr}>`,
+          content,
+          `</span></span></foreignObject></svg>${end}`,
+        ].join('')
       }
       return `${start}<span ${attr}="plain">${content}</span>${end}`
     })
@@ -46,6 +54,7 @@ function fittingHeader(md): void {
     state.tokens.forEach(token => {
       if (!target && token.type === 'heading_open') target = token
       if (target === undefined) return
+
       if (
         token.type === 'inline' &&
         token.children.some(

--- a/src/fitting/fitting.ts
+++ b/src/fitting/fitting.ts
@@ -1,8 +1,10 @@
 import Token from 'markdown-it/lib/token'
 import fittingCSS from './fitting.scss'
+import { Marp } from '../marp'
 
 export const css = fittingCSS
 export const attr = 'data-marp-fitting'
+export const shrink = 'data-marp-fitting-shrink'
 export const svgContentAttr = 'data-marp-fitting-svg-content'
 
 function wrapTokensByFittingToken(tokens: any[]): any[] {
@@ -12,9 +14,30 @@ function wrapTokensByFittingToken(tokens: any[]): any[] {
   return [open, ...tokens, new Token('marp_fitting_close', 'span', -1)]
 }
 
-/**
- * Detect `<!-- fit -->` comment keyword in headings.
- */
+function fittingCode(md, marp: Marp): void {
+  const { code_block, fence } = md.renderer.rules
+
+  const codeMatcher = /^(<pre[^>]*?><code[^>]*?>)([\s\S]*)(<\/code><\/pre>\n*)$/
+  const replacedRenderer = func => (...args) => {
+    const rendered: string = func(...args)
+    const { theme } = marp.lastGlobalDirectives
+    const { fittingCode } = marp.themeSet.getThemeProp(theme, 'meta')
+
+    if (fittingCode === 'false') return rendered
+
+    return rendered.replace(codeMatcher, (_, start, content, end) => {
+      if (marp.options.inlineSVG) {
+        return `${start}<svg ${attr}="svg" ${shrink}><foreignObject><span ${svgContentAttr}="pre">${content}</span></foreignObject></svg>${end}`
+      }
+      return `${start}<span ${attr}="plain">${content}</span>${end}`
+    })
+  }
+
+  md.renderer.rules.code_block = replacedRenderer(code_block)
+  md.renderer.rules.fence = replacedRenderer(fence)
+}
+
+// Detect `<!-- fit -->` comment keyword in headings.
 function fittingHeader(md): void {
   md.core.ruler.after('inline', 'marp_fitting_header', state => {
     let target = undefined
@@ -36,10 +59,11 @@ function fittingHeader(md): void {
   })
 }
 
-export function markdown(md, opts: { inlineSVG: boolean }): void {
+export function markdown(md, marp: Marp): void {
   md.use(fittingHeader)
+  md.use(fittingCode, marp)
 
-  if (opts.inlineSVG) {
+  if (marp.options.inlineSVG) {
     Object.assign(md.renderer.rules, {
       marp_fitting_open: () =>
         `<svg ${attr}="svg"><foreignObject><span ${svgContentAttr}>`,

--- a/src/fitting/fitting.ts
+++ b/src/fitting/fitting.ts
@@ -4,8 +4,9 @@ import { Marp } from '../marp'
 
 export const css = fittingCSS
 export const attr = 'data-marp-fitting'
-export const shrink = 'data-marp-fitting-shrink'
+export const code = 'data-marp-fitting-code'
 export const svgContentAttr = 'data-marp-fitting-svg-content'
+export const svgContentWrapAttr = 'data-marp-fitting-svg-content-wrap'
 
 function wrapTokensByFittingToken(tokens: any[]): any[] {
   const open = new Token('marp_fitting_open', 'span', 1)
@@ -27,7 +28,7 @@ function fittingCode(md, marp: Marp): void {
 
     return rendered.replace(codeMatcher, (_, start, content, end) => {
       if (marp.options.inlineSVG) {
-        return `${start}<svg ${attr}="svg" ${shrink}><foreignObject><span ${svgContentAttr}="pre">${content}</span></foreignObject></svg>${end}`
+        return `${start}<svg ${attr}="svg" ${code}><foreignObject><span ${svgContentAttr}><span ${svgContentWrapAttr}>${content}</span></span></foreignObject></svg>${end}`
       }
       return `${start}<span ${attr}="plain">${content}</span>${end}`
     })

--- a/src/fitting/observer.ts
+++ b/src/fitting/observer.ts
@@ -1,4 +1,4 @@
-import { attr, shrink } from './fitting'
+import { attr, code } from './fitting'
 
 export default function fittingObserver(): void {
   Array.from(
@@ -9,13 +9,13 @@ export default function fittingObserver(): void {
       const { scrollWidth, scrollHeight } = container
 
       let minWidth = 1
-      if (svg.hasAttribute(shrink)) {
-        const findSection = elm => {
+      if (svg.hasAttribute(code)) {
+        const findPre = elm => {
           if (!elm) return undefined
-          if (elm.localName === 'section') return elm
-          if (elm.parentElement) return findSection(elm.parentElement)
+          if (elm.localName === 'pre') return elm
+          if (elm.parentElement) return findPre(elm.parentElement)
         }
-        const section = findSection(svg)
+        const section = findPre(svg)
         if (section) minWidth = section.clientWidth
       }
 

--- a/src/fitting/observer.ts
+++ b/src/fitting/observer.ts
@@ -1,4 +1,4 @@
-import { attr } from './fitting'
+import { attr, shrink } from './fitting'
 
 export default function fittingObserver(): void {
   Array.from(
@@ -7,7 +7,19 @@ export default function fittingObserver(): void {
       const foreignObject = svg.firstChild as SVGForeignObjectElement
       const container = foreignObject.firstChild as HTMLSpanElement
       const { scrollWidth, scrollHeight } = container
-      const w = Math.max(scrollWidth, 1)
+
+      let minWidth = 1
+      if (svg.hasAttribute(shrink)) {
+        const findSection = elm => {
+          if (!elm) return undefined
+          if (elm.localName === 'section') return elm
+          if (elm.parentElement) return findSection(elm.parentElement)
+        }
+        const section = findSection(svg)
+        if (section) minWidth = section.clientWidth
+      }
+
+      const w = Math.max(scrollWidth, minWidth)
       const h = Math.max(scrollHeight, 1)
       const viewBox = `0 0 ${w} ${h}`
 

--- a/src/fitting/observer.ts
+++ b/src/fitting/observer.ts
@@ -9,14 +9,17 @@ export default function fittingObserver(): void {
       const { scrollWidth, scrollHeight } = container
 
       let minWidth = 1
+
       if (svg.hasAttribute(code)) {
-        const findPre = elm => {
-          if (!elm) return undefined
-          if (elm.localName === 'pre') return elm
-          if (elm.parentElement) return findPre(elm.parentElement)
-        }
-        const section = findPre(svg)
-        if (section) minWidth = section.clientWidth
+        const pre = svg.parentElement!.parentElement!
+        const computed = getComputedStyle(pre)
+        const mw = Math.ceil(
+          pre.clientWidth -
+            parseFloat(computed.paddingLeft!) -
+            parseFloat(computed.paddingRight!)
+        )
+
+        if (mw) minWidth = mw
       }
 
       const w = Math.max(scrollWidth, minWidth)

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -26,9 +26,6 @@ export interface MarpOptions extends MarpitOptions {
 export class Marp extends Marpit {
   options!: MarpOptions
 
-  /** @internal */
-  lastGlobalDirectives: any
-
   private renderedMath: boolean = false
 
   constructor(opts: MarpOptions = {}) {
@@ -84,7 +81,10 @@ export class Marp extends Marpit {
     }
 
     // Fitting
-    md.use(fittingPlugin.markdown, this)
+    const themeResolver: fittingPlugin.ThemeResolver = () =>
+      (this.lastGlobalDirectives || {}).theme
+
+    md.use(fittingPlugin.markdown, this, themeResolver)
   }
 
   highlighter(code: string, lang: string): string {

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -26,6 +26,9 @@ export interface MarpOptions extends MarpitOptions {
 export class Marp extends Marpit {
   options!: MarpOptions
 
+  /** @internal */
+  lastGlobalDirectives: any
+
   private renderedMath: boolean = false
 
   constructor(opts: MarpOptions = {}) {
@@ -65,7 +68,7 @@ export class Marp extends Marpit {
   applyMarkdownItPlugins(md = this.markdown) {
     super.applyMarkdownItPlugins(md)
 
-    const { emoji, inlineSVG, math } = this.options
+    const { emoji, math } = this.options
 
     // Emoji support
     md.use(emojiPlugin.markdown, emoji)
@@ -80,8 +83,8 @@ export class Marp extends Marpit {
       md.use(mathPlugin.markdown, opts, flag => (this.renderedMath = flag))
     }
 
-    // Fitting header
-    md.use(fittingPlugin.markdown, { inlineSVG })
+    // Fitting
+    md.use(fittingPlugin.markdown, this)
   }
 
   highlighter(code: string, lang: string): string {

--- a/test/fitting/observer.ts
+++ b/test/fitting/observer.ts
@@ -18,10 +18,10 @@ describe('Fitting observer', () => {
   context('when the fitting header is rendered', () => {
     let svg: SVGSVGElement
     let foreignObj: SVGForeignObjectElement
-    let contents: HTMLSpanElement
+    let content: HTMLSpanElement
 
     const setContentSize = (width, height) =>
-      Object.defineProperties(contents, {
+      Object.defineProperties(content, {
         scrollWidth: { configurable: true, get: () => width },
         scrollHeight: { configurable: true, get: () => height },
       })
@@ -31,7 +31,7 @@ describe('Fitting observer', () => {
 
       svg = document.querySelector('svg[data-marp-fitting="svg"]')
       foreignObj = svg.querySelector('foreignObject')
-      contents = foreignObj.querySelector('span[data-marp-fitting-svg-content]')
+      content = foreignObj.querySelector('span[data-marp-fitting-svg-content]')
 
       setContentSize(100, 200)
     })
@@ -87,6 +87,19 @@ describe('Fitting observer', () => {
       } finally {
         mock.mockRestore()
       }
+    })
+  })
+
+  // TODO: Add test case about when rendering code block
+  context('when the auto-scalable code block is rendered', () => {
+    let svg: SVGSVGElement
+    let pre: HTMLPreElement
+
+    beforeEach(() => {
+      document.body.innerHTML = new Marp().render('```\nauto-scalble\n```').html
+
+      svg = document.querySelector('svg[data-marp-fitting-code]')
+      pre = document.querySelector('section pre')
     })
   })
 })

--- a/test/fitting/observer.ts
+++ b/test/fitting/observer.ts
@@ -4,6 +4,12 @@ import Marp from '../../src/marp'
 import fittingObserver from '../../src/fitting/observer'
 
 describe('Fitting observer', () => {
+  const setContentSize = (content: HTMLElement, width, height) =>
+    Object.defineProperties(content, {
+      scrollWidth: { configurable: true, get: () => width },
+      scrollHeight: { configurable: true, get: () => height },
+    })
+
   it('calls window.requestAnimationFrame with myself', () => {
     const spy = jest.spyOn(window, 'requestAnimationFrame')
 
@@ -20,12 +26,6 @@ describe('Fitting observer', () => {
     let foreignObj: SVGForeignObjectElement
     let content: HTMLSpanElement
 
-    const setContentSize = (width, height) =>
-      Object.defineProperties(content, {
-        scrollWidth: { configurable: true, get: () => width },
-        scrollHeight: { configurable: true, get: () => height },
-      })
-
     beforeEach(() => {
       document.body.innerHTML = new Marp().render('# <!-- fit --> fitting').html
 
@@ -33,7 +33,7 @@ describe('Fitting observer', () => {
       foreignObj = svg.querySelector('foreignObject')
       content = foreignObj.querySelector('span[data-marp-fitting-svg-content]')
 
-      setContentSize(100, 200)
+      setContentSize(content, 100, 200)
     })
 
     it('updates SVG attributes into the content size', () => {
@@ -54,7 +54,7 @@ describe('Fitting observer', () => {
       fittingObserver()
       expect(svg.classList.contains('__reflow__')).toBe(true) // no change
 
-      setContentSize(200, 300)
+      setContentSize(content, 200, 300)
       fittingObserver()
       expect(foreignObj.getAttribute('width')).toBe('200')
       expect(foreignObj.getAttribute('height')).toBe('300')
@@ -63,7 +63,7 @@ describe('Fitting observer', () => {
     })
 
     it('keeps minimum svg size 1x1 even if content size is empty', () => {
-      setContentSize(0, 0)
+      setContentSize(content, 0, 0)
       fittingObserver()
 
       expect(foreignObj.getAttribute('width')).toBe('1')
@@ -90,16 +90,60 @@ describe('Fitting observer', () => {
     })
   })
 
-  // TODO: Add test case about when rendering code block
   context('when the auto-scalable code block is rendered', () => {
     let svg: SVGSVGElement
     let pre: HTMLPreElement
+    let content: HTMLSpanElement
 
     beforeEach(() => {
       document.body.innerHTML = new Marp().render('```\nauto-scalble\n```').html
 
       svg = document.querySelector('svg[data-marp-fitting-code]')
       pre = document.querySelector('section pre')
+      content = svg.querySelector('span[data-marp-fitting-svg-content]')
+
+      setContentSize(content, 200, 100)
+    })
+
+    const setPreWidth = clientWidth =>
+      Object.defineProperty(pre, 'clientWidth', {
+        configurable: true,
+        get: () => clientWidth,
+      })
+
+    it("restricts min width to <pre> element's width without padding", () => {
+      const computed = jest.spyOn(window, 'getComputedStyle')
+
+      try {
+        computed.mockImplementation(() => ({
+          paddingLeft: 0,
+          paddingRight: 0,
+          getPropertyValue: () => undefined,
+        }))
+
+        // pre width > svg width
+        setPreWidth(300)
+        fittingObserver()
+        expect(svg.getAttribute('viewBox')).toBe('0 0 300 100')
+
+        // svg width > pre width
+        setPreWidth(100)
+        fittingObserver()
+        expect(svg.getAttribute('viewBox')).toBe('0 0 200 100')
+
+        // Consider padding
+        computed.mockImplementation(() => ({
+          paddingLeft: '50px',
+          paddingRight: '70px',
+          getPropertyValue: () => undefined,
+        }))
+
+        setPreWidth(300) // 300 - 50 - 70 = 180px
+        fittingObserver()
+        expect(svg.getAttribute('viewBox')).toBe('0 0 200 100')
+      } finally {
+        computed.mockRestore()
+      }
     })
   })
 })

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -297,6 +297,12 @@ describe('Marp', () => {
   })
 
   describe('Element fitting', () => {
+    const loadCheerio = (html: string) =>
+      cheerio.load(html, {
+        lowerCaseAttributeNames: false,
+        lowerCaseTags: false,
+      })
+
     it('prepends CSS about fitting', () => {
       const { css } = marp().render('')
 
@@ -304,34 +310,107 @@ describe('Marp', () => {
       expect(css).toContain('[data-marp-fitting-svg-content]')
     })
 
-    context('when fit comment keyword contains in heading', () => {
-      const markdown = '# <!--fit--> fitting'
+    context(
+      'when fit comment keyword contains in heading (Fitting header)',
+      () => {
+        const markdown = '# <!--fit--> fitting'
 
-      it('wraps by <svg data-marp-fitting="svg">', () => {
-        const { html } = marp().render(markdown)
-        const $ = cheerio.load(html, {
-          lowerCaseAttributeNames: false,
-          lowerCaseTags: false,
+        it('wraps by <svg data-marp-fitting="svg">', () => {
+          const $ = loadCheerio(marp().render(markdown).html)
+          const svgContent = $(
+            [
+              'h1',
+              'svg[data-marp-fitting="svg"]',
+              'foreignObject',
+              'span[data-marp-fitting-svg-content]',
+            ].join('>')
+          )
+
+          expect(svgContent).toHaveLength(1)
+          expect($('h1').text()).toContain('fitting')
         })
+
+        it('wraps by <span data-marp-fitting="plain"> with disabled inlineSVG mode', () => {
+          const $ = loadCheerio(
+            marp({ inlineSVG: false }).render(markdown).html
+          )
+
+          expect($('h1 > span[data-marp-fitting="plain"]')).toHaveLength(1)
+          expect($('h1').text()).toContain('fitting')
+        })
+      }
+    )
+
+    context('with code block (Auto scaling for code block)', () => {
+      const markdown = '\tCODE BLOCK'
+
+      it('wraps code block by <svg data-marp-fitting="svg">', () => {
+        const $ = loadCheerio(marp().render(markdown).html)
         const svgContent = $(
           [
-            'h1',
-            'svg[data-marp-fitting="svg"]',
+            'pre',
+            'code',
+            'svg[data-marp-fitting="svg"][data-marp-fitting-code]',
             'foreignObject',
             'span[data-marp-fitting-svg-content]',
+            'span[data-marp-fitting-svg-content-wrap]',
           ].join('>')
         )
 
         expect(svgContent).toHaveLength(1)
-        expect($('h1').text()).toContain('fitting')
+        expect($('pre').text()).toContain('CODE BLOCK')
       })
 
       it('wraps by <span data-marp-fitting="plain"> with disabled inlineSVG mode', () => {
-        const { html } = marp({ inlineSVG: false }).render(markdown)
-        const $ = cheerio.load(html)
+        const $ = loadCheerio(marp({ inlineSVG: false }).render(markdown).html)
 
-        expect($('h1 > span[data-marp-fitting="plain"]')).toHaveLength(1)
-        expect($('h1').text()).toContain('fitting')
+        expect($('pre > code > span[data-marp-fitting="plain"]').length).toBe(1)
+        expect($('pre').text()).toContain('CODE BLOCK')
+      })
+
+      it('does not wrap by svg when specified theme has fittingCode meta as false', () => {
+        const instance = marp()
+        instance.themeSet.get('uncover').meta.fittingCode = 'false'
+
+        const uncover = `---\ntheme: uncover\n---\n\n${markdown}`
+        const $ = loadCheerio(instance.render(uncover).html)
+
+        expect($('section svg')).toHaveLength(0)
+      })
+    })
+
+    context('with fence (Auto scaling for fence)', () => {
+      const markdown = '```typescript\nconst a = 1\n```'
+
+      it('wraps code block by <svg data-marp-fitting="svg">', () => {
+        const $ = loadCheerio(marp().render(markdown).html)
+        const svgContent = $(
+          [
+            'pre',
+            'code.language-typescript',
+            'svg[data-marp-fitting="svg"][data-marp-fitting-code]',
+            'foreignObject',
+            'span[data-marp-fitting-svg-content]',
+            'span[data-marp-fitting-svg-content-wrap]',
+          ].join('>')
+        )
+
+        expect(svgContent).toHaveLength(1)
+        expect($('pre').text()).toContain('const a = 1')
+      })
+
+      it('wraps by <span data-marp-fitting="plain"> with disabled inlineSVG mode', () => {
+        const $ = loadCheerio(marp({ inlineSVG: false }).render(markdown).html)
+        const plainContent = $(
+          [
+            'pre',
+            'code.language-typescript',
+            'span[data-marp-fitting="plain"]',
+          ].join('>')
+        )
+
+        expect(plainContent).toHaveLength(1)
+        expect($('pre').text()).toContain('const a = 1')
       })
     })
   })

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -79,11 +79,11 @@ describe('Marp', () => {
 
           // Code block
           const $block = cheerio.load(instance.render('```\n👍\n```').html)
-          expect($block('pre > code > img[data-marp-twemoji]')).toHaveLength(1)
+          expect($block('pre > code img[data-marp-twemoji]')).toHaveLength(1)
 
           // Fence
           const $fence = cheerio.load(instance.render('\t👍👍👍').html)
-          expect($fence('pre > code > img[data-marp-twemoji]')).toHaveLength(3)
+          expect($fence('pre > code img[data-marp-twemoji]')).toHaveLength(3)
         })
 
         it('does not convert unicode emoji in HTML attribute', () => {
@@ -350,7 +350,7 @@ describe('Marp', () => {
       const $ = cheerio.load(marp().markdown.render('```\n# test\n```'))
 
       it('highlights code automatically', () =>
-        expect($('code > [class^="hljs-"]').length).toBeGreaterThan(0))
+        expect($('code [class^="hljs-"]').length).toBeGreaterThan(0))
     })
 
     context('when fence is rendered with specified lang', () => {
@@ -358,7 +358,7 @@ describe('Marp', () => {
 
       it('highlights code with specified lang', () => {
         expect($('code.language-markdown')).toHaveLength(1)
-        expect($('code > .hljs-section')).toHaveLength(1)
+        expect($('code .hljs-section')).toHaveLength(1)
       })
     })
 
@@ -370,7 +370,7 @@ describe('Marp', () => {
         )
 
         it('disables highlight', () =>
-          expect($('code > [class^="hljs-"]')).toHaveLength(0))
+          expect($('code [class^="hljs-"]')).toHaveLength(0))
       })
     })
 
@@ -387,7 +387,7 @@ describe('Marp', () => {
       const $ = cheerio.load(instance.markdown.render('```markdown\ntest\n```'))
 
       it('highlights with custom highlighter', () =>
-        expect($('code > .customized')).toHaveLength(1))
+        expect($('code .customized')).toHaveLength(1))
     })
   })
 

--- a/themes/default.scss
+++ b/themes/default.scss
@@ -34,6 +34,17 @@ h6 {
   font-size: 0.9em;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  svg[data-marp-fitting='svg'] {
+    max-height: 563px; // Slide height - padding * 2
+  }
+}
+
 hr {
   height: 0;
   padding-top: 0.25em;
@@ -42,6 +53,11 @@ hr {
 pre {
   border: 1px solid #999;
   line-height: 1.15;
+
+  code svg[data-marp-fitting='svg'] {
+    // Slide height - padding * 2 - code's padding * 3 - code's border * 2
+    max-height: 529px;
+  }
 }
 
 header,
@@ -59,10 +75,6 @@ header {
 
 footer {
   bottom: 21px;
-}
-
-svg[data-marp-fitting='svg'] {
-  max-height: 563px; // Slide height - padding * 2
 }
 
 section {

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -121,7 +121,7 @@ code {
 pre {
   display: block;
   margin: 1em 0 0 0;
-  min-height: 2em;
+  min-height: 1em;
   overflow: auto;
 
   code {

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -66,6 +66,10 @@ h4,
 h5,
 h6 {
   margin: 0.5em 0 0 0;
+
+  svg[data-marp-fitting='svg'] {
+    max-height: 580px; // Slide height - padding * 2
+  }
 }
 
 h1 {
@@ -130,6 +134,10 @@ pre {
     min-width: 100%;
     padding: 0.5em;
     font-size: 0.7em;
+
+    svg[data-marp-fitting='svg'] {
+      max-height: calc(580px - 1em);
+    }
   }
 }
 
@@ -180,10 +188,6 @@ table {
   }
 }
 
-svg[data-marp-fitting='svg'] {
-  max-height: 580px; // Slide height - padding * 2
-}
-
 section {
   background-image: linear-gradient(
     135deg,
@@ -222,16 +226,19 @@ section {
     flex-wrap: nowrap;
     justify-content: center;
 
-    svg[data-marp-fitting='svg'] {
-      --preserve-aspect-ratio: xMidYMid meet;
-    }
-
     h1,
     h2,
     h3,
     h4,
     h5,
-    h6,
+    h6 {
+      text-align: center;
+
+      svg[data-marp-fitting='svg'] {
+        --preserve-aspect-ratio: xMidYMid meet;
+      }
+    }
+
     p {
       text-align: center;
     }

--- a/themes/uncover.scss
+++ b/themes/uncover.scss
@@ -3,6 +3,7 @@
  *
  * @theme uncover
  * @author Yuki Hattori
+ * @fittingCode false
  */
 
 @mixin color-scheme($bg: #fdfcff, $text: #202228, $highlight: #009dd5) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,9 +153,9 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@marp-team/marpit@^0.0.12":
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.0.12.tgz#a4063601dae6f94aadc27f7dce128b3dd0730726"
+"@marp-team/marpit@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.0.13.tgz#3f48b43fd911f2d32ff8c2eea0f8b8e4f12f10ae"
   dependencies:
     js-yaml "^3.12.0"
     lodash.kebabcase "^4.1.1"


### PR DESCRIPTION
This PR will support auto scaling code block & fence in default theme and gaia theme.

We have seen a lot of slides created by pre-released Marp, but sometimes several code blocks and fences have cropped codes.

In marp-core, we can make use of experience about fitting header. We apply auto scaling to code block and fence when `inlineSVG` option is true.

|[Before](https://github.com/marp-team/marp-core/files/2321876/auto-scale-before.pdf)|[After](https://github.com/marp-team/marp-core/files/2321877/auto-scale-after.pdf)|
|:---:|:---:|
|![auto-scale-before](https://user-images.githubusercontent.com/3993388/44632583-3ac70c00-a9b8-11e8-9653-626bcb285be3.png)|![auto-scale-after](https://user-images.githubusercontent.com/3993388/44632584-3ef32980-a9b8-11e8-919a-85237a21569a.png)|

> This example is following [Deckset's example](https://docs.decksetapp.com/English.lproj/Formatting/06-code-blocks.html#automatic-scaling). We can get the same feature as Deckset by this implementation. (See yhatt/marp#60)

This feature is available only in `default` theme and `gaia` theme. `uncover` theme has disabled this feature because we use elastic code style that has not compatible with auto scaling by SVG.

### ToDo

- [x] Fix unavailable tests
- [x] Add tests about auto scaling