### PR TITLE
Apply color directive to heading of default theme

### DIFF
--- a/themes/default.scss
+++ b/themes/default.scss
@@ -189,4 +189,15 @@ section {
       }
     }
   }
+
+  &[data-color] {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      color: currentColor;
+    }
+  }
 }


### PR DESCRIPTION
Previously the `<h1>`'s text color of default theme was fixed to deep blue even if `color` directive is defined. This PR will fix this style to override with `currentColor` when color directive is defined.

```markdown
<!-- color: red -->

# <h1>

## <h2>

### <h3>
```

|Before|After|
|:---:|:---:|
|![before](https://user-images.githubusercontent.com/3993388/44954719-6c246800-aee1-11e8-8629-5bc8e8a8d3d6.png)|![after](https://user-images.githubusercontent.com/3993388/44954720-6f1f5880-aee1-11e8-8986-8ecdcd1a6519.png)|
