### PR TITLE
Support auto scaling for math block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support auto scaling for math block ([#30](https://github.com/marp-team/marp-core/pull/30))
+
 ## v0.0.6 - 2018-09-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -120,17 +120,27 @@ When the headings contains `<!-- fit -->` comment, the size of headings will res
 
 This syntax is similar to [Deckset's `[fit]` keyword](https://docs.decksetapp.com/English.lproj/Formatting/01-headings.html), but we use HTML comment to hide a fit keyword on Markdown rendered as document.
 
-#### Code block
+#### Math block
 
-In several themes, we will shrink the viewing size of the code block to fit automatically if it is bigger than slide size. It means that the code on exported PDF is not cropped and not shown an unnecessary scrollbar.
+We can scale-down the viewing size of math block (surrounded by `$$`) to fit a slide automatically.
+
+|              Traditional rendering               |              Auto scaling               |
+| :----------------------------------------------: | :-------------------------------------: |
+| ![Traditional rendering](https://bit.ly/2NXoHuW) | ![Auto scaling](https://bit.ly/2M6LyCk) |
+
+#### Code block (Only for `default` and `gaia` theme)
+
+Several themes also can scale-down the viewing size of the code block to fit a slide.
 
 |              Traditional rendering               |              Auto scaling               |
 | :----------------------------------------------: | :-------------------------------------: |
 | ![Traditional rendering](https://bit.ly/2LyEnmi) | ![Auto scaling](https://bit.ly/2N4yWQZ) |
 
-This feature is available on `default` and `gaia` theme. `uncover` theme has disabled this feature because we use elastic style that has not compatible with auto scaling.
+These features means that the contents on a slide are not cropped, and not shown unnecessary scrollbars in code.
 
-> :warning: We won't detect whether the code block actually protrudes from the slide.
+> :information_source: `uncover` theme has disabled scaling for code block because we use elastic style that has not compatible with it.
+
+> :warning: We won't detect whether the math and code block actually protrudes from the slide. It might not work scaling correctly when there are many elements in a slide.
 
 ## Constructor options
 

--- a/src/fitting/observer.ts
+++ b/src/fitting/observer.ts
@@ -1,4 +1,4 @@
-import { attr, code } from './fitting'
+import { attr, code, math } from './fitting'
 
 export default function fittingObserver(): void {
   Array.from(
@@ -9,12 +9,15 @@ export default function fittingObserver(): void {
       const { scrollWidth, scrollHeight } = container
 
       let minWidth = 1
+      let shrinkBase: HTMLElement | undefined
 
-      if (svg.hasAttribute(code)) {
-        const pre = svg.parentElement!.parentElement!
-        const computed = getComputedStyle(pre)
+      if (svg.hasAttribute(code)) shrinkBase = svg.parentElement!.parentElement! // <pre>
+      if (svg.hasAttribute(math)) shrinkBase = svg.parentElement! // <p>
+
+      if (shrinkBase) {
+        const computed = getComputedStyle(shrinkBase)
         const mw = Math.ceil(
-          pre.clientWidth -
+          shrinkBase.clientWidth -
             parseFloat(computed.paddingLeft!) -
             parseFloat(computed.paddingRight!)
         )

--- a/src/math/katex.scss
+++ b/src/math/katex.scss
@@ -3,3 +3,12 @@
 .katex-display {
   margin: 0;
 }
+
+// Centering with auto scaling
+svg[data-marp-fitting-math] {
+  --preserve-aspect-ratio: xMidYMid meet;
+
+  [data-marp-fitting-svg-content] {
+    margin: 0 auto;
+  }
+}

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -448,6 +448,32 @@ describe('Marp', () => {
         expect($('pre').text()).toContain('const a = 1')
       })
     })
+
+    context('with math block', () => {
+      const markdown = '$$ y=ax^2 $$'
+
+      it('wraps code block by <svg data-marp-fitting="svg">', () => {
+        const $ = loadCheerio(marp().render(markdown).html)
+        const svgContent = `${$(
+          [
+            'p',
+            'svg[data-marp-fitting="svg"][data-marp-fitting-math]',
+            'foreignObject',
+            'span[data-marp-fitting-svg-content]',
+            'span[data-marp-fitting-svg-content-wrap]',
+          ].join('>')
+        )} .katex`
+
+        expect(svgContent.length).toBeTruthy()
+      })
+
+      it('wraps by <span data-marp-fitting="plain"> with disabled inlineSVG mode', () => {
+        const $ = loadCheerio(marp({ inlineSVG: false }).render(markdown).html)
+        const plainContent = $('p > span[data-marp-fitting="plain"] .katex')
+
+        expect(plainContent.length).toBeTruthy()
+      })
+    })
   })
 
   describe('themeSet property', () => {

--- a/themes/default.scss
+++ b/themes/default.scss
@@ -7,6 +7,10 @@
 @import '~github-markdown-css';
 @import '~highlight.js/styles/github-gist';
 
+svg[data-marp-fitting='svg'] {
+  max-height: 563px; // Slide height - padding * 2
+}
+
 h1 {
   border-bottom: none;
   color: #246;
@@ -32,17 +36,6 @@ h5 {
 
 h6 {
   font-size: 0.9em;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  svg[data-marp-fitting='svg'] {
-    max-height: 563px; // Slide height - padding * 2
-  }
 }
 
 hr {

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -59,6 +59,10 @@ $color-secondary: #81d4fa;
   }
 }
 
+svg[data-marp-fitting='svg'] {
+  max-height: 580px; // Slide height - padding * 2
+}
+
 h1,
 h2,
 h3,
@@ -66,10 +70,6 @@ h4,
 h5,
 h6 {
   margin: 0.5em 0 0 0;
-
-  svg[data-marp-fitting='svg'] {
-    max-height: 580px; // Slide height - padding * 2
-  }
 }
 
 h1 {
@@ -254,7 +254,7 @@ section {
         text-align: left;
       }
 
-      svg[data-marp-fitting='svg'] {
+      svg[data-marp-fitting='svg']:not([data-marp-fitting-math]) {
         --preserve-aspect-ratio: xMinYMin meet;
       }
     }


### PR DESCRIPTION
This PR will apply the auto-scaling feature to math block (`$$`). We have applied the know-how of code block fitting into math. It is similar to [Deckset's Formula Autoscaling](https://docs.decksetapp.com/English.lproj/Formatting/08-formulas.html#formula-autoscaling).

It would resolve yhatt/marp#212.

```markdown
---
theme: uncover
---

## Fitting math block

<!-- from https://katex.org/ -->
$$
\displaystyle {1 +  \frac{q^2}{(1-q)}+\frac{q^6}{(1-q)(1-q^2)}+\cdots }= \prod_{j=0}^{\infty}\frac{1}{(1-q^{5j+2})(1-q^{5j+3})}, \quad\quad \text{for }\lvert q\rvert<1.
$$
```

|              Traditional rendering               |              Auto scaling               |
| :----------------------------------------------: | :-------------------------------------: |
| ![Traditional rendering](https://bit.ly/2NXoHuW) | ![Auto scaling](https://bit.ly/2M6LyCk) |