### PR TITLE
Use for-of loop instead of iterate functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add CI test against Node v6 Boron Maintenance LTS ([#35](https://github.com/marp-team/marp-core/pull/35))
 
+### Changed
+
+- Update code style to use `for-of` loop instead of iterate functions if possible ([#34](https://github.com/marp-team/marp-core/pull/34))
+
 ## v0.0.9 - 2018-09-20
 
 ### Changed

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -38,31 +38,38 @@ export function markdown(md, opts: EmojiOptions): void {
 
   if (opts.unicode) {
     md.core.ruler.after('inline', 'marp_unicode_emoji', ({ tokens }) => {
-      tokens.forEach(token => {
-        if (token.type !== 'inline') return
+      for (const token of tokens) {
+        if (token.type === 'inline') {
+          const newChildren: any[] = []
 
-        token.children = token.children.reduce((arr, t) => {
-          if (t.type !== 'text') return [...arr, t]
+          for (const t of token.children) {
+            if (t.type === 'text') {
+              const splittedByEmoji = t.content.split(regexForSplit)
 
-          return [
-            ...arr,
-            ...t.content.split(regexForSplit).reduce(
-              (splitedArr, text, idx) =>
-                text.length === 0
-                  ? splitedArr
-                  : [
-                      ...splitedArr,
-                      Object.assign(new Token(), {
-                        ...t,
-                        content: text,
-                        type: idx % 2 ? 'unicode_emoji' : 'text',
-                      }),
-                    ],
-              []
-            ),
-          ]
-        }, [])
-      })
+              newChildren.push(
+                ...splittedByEmoji.reduce(
+                  (splitedArr, text, idx) =>
+                    text.length === 0
+                      ? splitedArr
+                      : [
+                          ...splitedArr,
+                          Object.assign(new Token(), {
+                            ...t,
+                            content: text,
+                            type: idx % 2 ? 'unicode_emoji' : 'text',
+                          }),
+                        ],
+                  []
+                )
+              )
+            } else {
+              newChildren.push(t)
+            }
+          }
+
+          token.children = newChildren
+        }
+      }
     })
 
     md.renderer.rules.unicode_emoji = (token: any[], idx: number): string =>

--- a/src/fitting/fitting.ts
+++ b/src/fitting/fitting.ts
@@ -52,7 +52,7 @@ function fittingHeader(md): void {
   md.core.ruler.after('inline', 'marp_fitting_header', state => {
     let target = undefined
 
-    state.tokens.forEach(token => {
+    for (const token of state.tokens) {
       if (!target && token.type === 'heading_open') target = token
       if (target === undefined) return
 
@@ -66,7 +66,7 @@ function fittingHeader(md): void {
       } else if (token.type === 'heading_close') {
         target = undefined
       }
-    })
+    }
   })
 }
 

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -40,7 +40,7 @@ export function markdown(md, opts: {}, update: (to: boolean) => void): void {
   // Parse math syntax by using markdown-it-katex
   md.use(markdownItKatex)
 
-  Object.keys(rules).forEach(rule => {
+  for (const rule of Object.keys(rules)) {
     const kind = rules[rule]
     const original = md[kind].ruler.__rules__[md[kind].ruler.__find__(rule)].fn
 
@@ -50,7 +50,7 @@ export function markdown(md, opts: {}, update: (to: boolean) => void): void {
 
       return ret
     })
-  })
+  }
 
   // Swap renderer to use the latest KaTeX
   md.renderer.rules.math_inline = (tokens, idx) => {

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -205,7 +205,7 @@ describe('Marp', () => {
         root => {
           root.walkAtRules('font-face', rule => {
             rule.walkDecls('src', decl => {
-              urls.forEach(url => expect(decl.value).toContain(url))
+              for (const url of urls) expect(decl.value).toContain(url)
             })
           })
         },
@@ -504,7 +504,7 @@ describe('Marp', () => {
     })
 
     // Plain text rendering
-    ;['text', 'plain', 'noHighlight', 'no-highlight'].forEach(lang => {
+    for (const lang of ['text', 'plain', 'noHighlight', 'no-highlight']) {
       context(`when fence is rendered with ${lang} lang`, () => {
         const $ = cheerio.load(
           marp().markdown.render(`\`\`\`${lang}\n# test\n\`\`\``)
@@ -513,7 +513,7 @@ describe('Marp', () => {
         it('disables highlight', () =>
           expect($('code [class^="hljs-"]')).toHaveLength(0))
       })
-    })
+    }
 
     context('with overriden #highlighter', () => {
       const instance = marp()


### PR DESCRIPTION
This PR replace iterate functions like `Array.forEach()` or `Array.reduce()` with `for-of` loop statement. It is following the change in marp-team/marpit#79, but Marp core has received few improvements of performance unlike Marpit.

In addition, some `Array.reduce()` are not replaced because of using index from third argument of callback.