### PR TITLE
Add CI test against Node v6 Boron Maintenance LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,19 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/node:8.12.0
+references:
+  base: &base
     working_directory: ~/marp-core
     steps:
       - checkout
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "yarn.lock" }}-{{ .Branch }}
-            - v1-dependencies-{{ checksum "yarn.lock" }}-
-            - v1-dependencies-
+            - v1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
+            - v1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-
+            - v1-dependencies-{{ .Environment.CIRCLE_JOB }}-
 
       - run: yarn install
 
       - save_cache:
-          key: v1-dependencies-{{ checksum "yarn.lock" }}-{{ .Branch }}
+          key: v1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
           paths:
             - node_modules
             - ~/.cache/yarn
@@ -51,3 +48,22 @@ jobs:
       - store_artifacts:
           path: ./coverage
           destination: coverage
+
+version: 2
+jobs:
+  '8.12.0':
+    <<: *base
+    docker:
+      - image: circleci/node:8.12.0
+
+  '6.14.2':
+    <<: *base
+    docker:
+      - image: circleci/node:6.14.2
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - 8.12.0
+      - 6.14.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add CI test against Node v6 Boron Maintenance LTS ([#35](https://github.com/marp-team/marp-core/pull/35))
+
 ## v0.0.9 - 2018-09-20
 
 ### Changed

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,10 +4,9 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{j,t}s'],
   coveragePathIgnorePatterns: ['/node_modules/', '.*\\.d\\.ts'],
   coverageThreshold: { global: { lines: 95 } },
-  transform: {
-    ...jestPreset.transform,
+  transform: Object.assign({}, jestPreset.transform, {
     '^.*\\.s?css$': '<rootDir>/test/_transformers/css.ts',
-  },
+  }),
   testEnvironment: 'node',
   testRegex: '(/(test|__tests__)/(?!_).*|(\\.|/)(test|spec))\\.[jt]s$',
   testURL: 'http://localhost',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "lib/",
     "types/"
   ],
+  "engines": {
+    "node": ">=6.14.2"
+  },
   "scripts": {
     "build": "yarn --silent clean && rollup -c",
     "check-ts": "tsc --noEmit",


### PR DESCRIPTION
[Marp CLI](https://github.com/marp-team/marp-cli) is supported Node v6.14.2 (Boron Maintenance LTS), but Marp core is not supported it officially. We will add CI test against Node v6.14.2 on CircleCI.