### PR TITLE
Fix fitting header regression with broken comment traversing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix fitting header regression with broken comment traversing ([#37](https://github.com/marp-team/marp-core/pull/37))
+
 ## v0.0.10 - 2018-10-05
 
 ### Added

--- a/src/fitting/fitting.ts
+++ b/src/fitting/fitting.ts
@@ -54,17 +54,18 @@ function fittingHeader(md): void {
 
     for (const token of state.tokens) {
       if (!target && token.type === 'heading_open') target = token
-      if (target === undefined) return
 
-      if (
-        token.type === 'inline' &&
-        token.children.some(
-          t => t.type === 'marpit_comment' && t.content === 'fit'
-        )
-      ) {
-        token.children = wrapTokensByFittingToken(token.children)
-      } else if (token.type === 'heading_close') {
-        target = undefined
+      if (target) {
+        if (
+          token.type === 'inline' &&
+          token.children.some(
+            t => t.type === 'marpit_comment' && t.content === 'fit'
+          )
+        ) {
+          token.children = wrapTokensByFittingToken(token.children)
+        } else if (token.type === 'heading_close') {
+          target = undefined
+        }
       }
     }
   })

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -348,31 +348,33 @@ describe('Marp', () => {
     context(
       'when fit comment keyword contains in heading (Fitting header)',
       () => {
-        const markdown = '# <!--fit--> fitting'
+        const baseMd = '# <!--fit--> fitting'
 
-        it('wraps by <svg data-marp-fitting="svg">', () => {
-          const $ = loadCheerio(marp().render(markdown).html)
-          const svgContent = $(
-            [
-              'h1',
-              'svg[data-marp-fitting="svg"]',
-              'foreignObject',
-              'span[data-marp-fitting-svg-content]',
-            ].join('>')
-          )
+        for (const markdown of [baseMd, `text\n\n${baseMd}`]) {
+          it('wraps by <svg data-marp-fitting="svg">', () => {
+            const $ = loadCheerio(marp().render(markdown).html)
+            const svgContent = $(
+              [
+                'h1',
+                'svg[data-marp-fitting="svg"]',
+                'foreignObject',
+                'span[data-marp-fitting-svg-content]',
+              ].join('>')
+            )
 
-          expect(svgContent).toHaveLength(1)
-          expect($('h1').text()).toContain('fitting')
-        })
+            expect(svgContent).toHaveLength(1)
+            expect($('h1').text()).toContain('fitting')
+          })
 
-        it('wraps by <span data-marp-fitting="plain"> with disabled inlineSVG mode', () => {
-          const $ = loadCheerio(
-            marp({ inlineSVG: false }).render(markdown).html
-          )
+          it('wraps by <span data-marp-fitting="plain"> with disabled inlineSVG mode', () => {
+            const $ = loadCheerio(
+              marp({ inlineSVG: false }).render(markdown).html
+            )
 
-          expect($('h1 > span[data-marp-fitting="plain"]')).toHaveLength(1)
-          expect($('h1').text()).toContain('fitting')
-        })
+            expect($('h1 > span[data-marp-fitting="plain"]')).toHaveLength(1)
+            expect($('h1').text()).toContain('fitting')
+          })
+        }
       }
     )
 


### PR DESCRIPTION
#34's improvement causes broken traverse of fitting comments. 

https://github.com/marp-team/marp-core/blob/23d21eab1bce99338d6f2d68cd6448659a681f25/src/fitting/fitting.ts#L57

This `return` had meant as to continue loop in iterate function. It will *exit from the parent function* in `for-of` loop.

Our test had not covered in this case. We've added the test of fitting comment with post-token at 04ce579.