### PR TITLE
Provide CJS version bundle for browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Provide CJS version bundle for browser ([#41](https://github.com/marp-team/marp-core/pull/41))
+- Add `observe` argument into functions for browser to allow controlling observation frames ([#41](https://github.com/marp-team/marp-core/pull/41))
+
 ### Fixed
 
 - Add yarn resolutions to flatten katex to prevent double-bundling ([#40](https://github.com/marp-team/marp-core/pull/40))
+- Prevent reflow by calling `setAttribute` in browser context only if value is updated ([#41](https://github.com/marp-team/marp-core/pull/41))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Support collecting HTML comments for presenter notes, from [Marpit v0.2.0](https://github.com/marp-team/marpit/releases/v0.2.0) ([#39](https://github.com/marp-team/marp-core/pull/39))
 - Provide CJS version bundle for browser ([#41](https://github.com/marp-team/marp-core/pull/41))
 - Add `observe` argument into functions for browser to allow controlling observation frames ([#41](https://github.com/marp-team/marp-core/pull/41))
 
@@ -15,7 +16,6 @@
 ### Changed
 
 - Update license author to marp-team ([#38](https://github.com/marp-team/marp-core/pull/38))
-- Support collecting HTML comments for presenter notes, from [Marpit v0.2.0](https://github.com/marp-team/marpit/releases/v0.2.0) ([#39](https://github.com/marp-team/marp-core/pull/39))
 
 ## v0.0.11 - 2018-10-09
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 #### Separated bundle
 
-We also provide a separated bundle [`lib/browser.js`](https://cdn.jsdelivr.net/npm/@marp-team/marp-core/lib/browser.js) for browser context. It is useful when you cannot use bundler for the browser, like [@marp-team/marp-cli](https://github.com/marp-team/marp-cli).
+We also provide a separated bundle [`lib/browser.js`](https://cdn.jsdelivr.net/npm/@marp-team/marp-core/lib/browser.js) for browser context. It is useful when you cannot use bundler.
 
 Loading `lib/browser.js` will bring the almost same result as running `Marp.ready()`. Thus, you could use it through CDN as below:
 
@@ -49,6 +49,8 @@ Loading `lib/browser.js` will bring the almost same result as running `Marp.read
 </body>
 </html>
 ```
+
+CommonJS bundle is also provided in `lib/browser.cjs.js`. It have to call manually as same as `Marp.ready()`.
 
 ## Features
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,4 +42,9 @@ export default [
     output: { file: pkg.marpBrowser, format: 'iife' },
     plugins,
   },
+  {
+    input: 'src/browser.ts',
+    output: { file: 'lib/browser.cjs.js', format: 'cjs' },
+    plugins,
+  },
 ]

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,5 @@
 import fittingObserver from './fitting/observer'
 
-export default function browser(): void {
-  fittingObserver()
+export default function browser(observe = true): void {
+  fittingObserver(observe)
 }

--- a/src/fitting/observer.ts
+++ b/src/fitting/observer.ts
@@ -7,7 +7,7 @@ const updateAttr = (elm: Element, attr: string, value: string): true | void => {
   }
 }
 
-export default function fittingObserver(): void {
+export default function fittingObserver(observe = true): void {
   Array.from(
     document.querySelectorAll<HTMLElement>(`svg[${attr}="svg"]`),
     svg => {
@@ -51,5 +51,5 @@ export default function fittingObserver(): void {
       }
     }
   )
-  window.requestAnimationFrame(fittingObserver)
+  if (observe) window.requestAnimationFrame(() => fittingObserver(observe))
 }

--- a/src/fitting/observer.ts
+++ b/src/fitting/observer.ts
@@ -1,5 +1,12 @@
 import { attr, code, math } from './fitting'
 
+const updateAttr = (elm: Element, attr: string, value: string): true | void => {
+  if (elm.getAttribute(attr) !== value) {
+    elm.setAttribute(attr, value)
+    return true
+  }
+}
+
 export default function fittingObserver(): void {
   Array.from(
     document.querySelectorAll<HTMLElement>(`svg[${attr}="svg"]`),
@@ -29,18 +36,18 @@ export default function fittingObserver(): void {
       const h = Math.max(scrollHeight, 1)
       const viewBox = `0 0 ${w} ${h}`
 
-      foreignObject.setAttribute('width', `${w}`)
-      foreignObject.setAttribute('height', `${h}`)
-
-      svg.setAttribute(
+      updateAttr(foreignObject, 'width', `${w}`)
+      updateAttr(foreignObject, 'height', `${h}`)
+      updateAttr(
+        svg,
         'preserveAspectRatio',
         getComputedStyle(svg).getPropertyValue('--preserve-aspect-ratio') ||
           'xMinYMin meet'
       )
 
-      if (svg.getAttribute('viewBox') !== viewBox) {
-        svg.setAttribute('viewBox', viewBox)
-        svg.classList.toggle('__reflow__') // for incremental update
+      // for incremental update
+      if (updateAttr(svg, 'viewBox', viewBox)) {
+        svg.classList.toggle('__reflow__')
       }
     }
   )

--- a/test/fitting/observer.ts
+++ b/test/fitting/observer.ts
@@ -16,7 +16,19 @@ describe('Fitting observer', () => {
     const spy = jest.spyOn(window, 'requestAnimationFrame')
 
     fittingObserver()
-    expect(spy).toHaveBeenCalledWith(fittingObserver)
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    spy.mock.calls[0][0]()
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  context('with observe argument is false', () => {
+    it('does not call window.requestAnimationFrame', () => {
+      const spy = jest.spyOn(window, 'requestAnimationFrame')
+
+      fittingObserver(false)
+      expect(spy).not.toHaveBeenCalled()
+    })
   })
 
   context('when the fitting header is rendered', () => {


### PR DESCRIPTION
This PR will provide CJS version bundle for browser. It would be used in [marp-team/marp-web](https://github.com/marp-team/marp-web).

And these improvements also are including.

- Added `observe` argument to allow controlling Marp Core's observation event in the integrated app. By setting `false`, it would not call `requestAnimationFrame` within function.
- Prevent reflow in Chrome by calling `setAttribute` only if value is updated.