### PR TITLE
Forces reflow on updated fitting elements in Edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Force reflow on updated fitting elements in Edge ([#43](https://github.com/marp-team/marp-core/pull/43))
+
 ## v0.0.12 - 2018-10-13
 
 ### Added

--- a/src/fitting/fitting.scss
+++ b/src/fitting/fitting.scss
@@ -1,8 +1,11 @@
 svg[data-marp-fitting='svg'] {
   display: block;
   height: auto;
-  position: static;
   width: 100%;
+
+  @supports (-ms-ime-align: auto) {
+    position: static;
+  }
 }
 
 svg[data-marp-fitting='svg'].__reflow__ {
@@ -10,7 +13,9 @@ svg[data-marp-fitting='svg'].__reflow__ {
   content: '';
 
   // Trigger reflow for Edge
-  position: relative;
+  @supports (-ms-ime-align: auto) {
+    position: relative;
+  }
 }
 
 [data-marp-fitting-svg-content] {

--- a/src/fitting/fitting.scss
+++ b/src/fitting/fitting.scss
@@ -1,12 +1,16 @@
 svg[data-marp-fitting='svg'] {
   display: block;
   height: auto;
+  position: static;
   width: 100%;
 }
 
 svg[data-marp-fitting='svg'].__reflow__ {
   // Trigger reflow for Firefox
   content: '';
+
+  // Trigger reflow for Edge
+  position: relative;
 }
 
 [data-marp-fitting-svg-content] {


### PR DESCRIPTION
Microsoft Edge would not trigger the browser reflow even if fitting elements are updated. When slide DOM is updated incrementally like [marp-web](https://github.com/marp-team/marp-web), the followed elements become to have incorrect positions.

In Firefox, we avoid this issue by blinking `__reflow__` class to trigger reflow forcely. The same approach would work in Edge too.