### PR TITLE
Remove markdown-it-katex by porting math syntax parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+- Remove unmaintained [markdown-it-katex](https://github.com/waylonflinn/markdown-it-katex) by porting math syntax parser ([#47](https://github.com/marp-team/marp-core/issues/47), [#48](https://github.com/marp-team/marp-core/pull/48))
+
 ## v0.1.0 - 2018-11-06
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -88,9 +88,6 @@
     "twemoji": "^11.2.0",
     "xss": "^1.0.3"
   },
-  "resolutions": {
-    "katex": "^0.10.0"
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "katex": "^0.10.0",
     "markdown-it": "^8.4.2",
     "markdown-it-emoji": "^1.4.0",
-    "markdown-it-katex": "^2.0.3",
     "postcss": "^7.0.5",
     "twemoji": "^11.2.0",
     "xss": "^1.0.3"

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -1,29 +1,123 @@
 import katex from 'katex'
-import markdownItKatex from 'markdown-it-katex'
 import postcss from 'postcss'
 import katexScss from './katex.scss'
 
 const convertedCSS = {}
 const katexMatcher = /url\(['"]?fonts\/(.*?)['"]?\)/g
-const rules = { math_block: 'block', math_inline: 'inline' }
 
 export function css(path?: string): string {
   if (!path) return katexScss
 
   return (convertedCSS[path] =
     convertedCSS[path] ||
-    postcss([
-      postcss.plugin('marp-math-katex-font-path', () => css =>
-        css.walkAtRules('font-face', rule =>
-          rule.walkDecls('src', decl => {
-            decl.value = decl.value.replace(
-              katexMatcher,
-              (_, matched) => `url('${path}${matched}')`
-            )
-          })
-        )
-      ),
-    ]).process(katexScss).css)
+    postcss(css =>
+      css.walkAtRules('font-face', rule =>
+        rule.walkDecls('src', decl => {
+          decl.value = decl.value.replace(
+            katexMatcher,
+            (_, matched) => `url('${path}${matched}')`
+          )
+        })
+      )
+    ).process(katexScss).css)
+}
+
+function isValidDelim(state, pos = state.pos) {
+  const ret = { openable: true, closable: true }
+  const { posMax, src } = state
+  const prev = pos > 0 ? src.charCodeAt(pos - 1) : -1
+  const next = pos + 1 <= posMax ? src.charCodeAt(pos + 1) : -1
+
+  if (next === 0x20 || next === 0x09) ret.openable = false
+  if (prev === 0x20 || prev === 0x09 || (next >= 0x30 && next <= 0x39)) {
+    ret.closable = false
+  }
+
+  return ret
+}
+
+function parseInlineMath(state, silent) {
+  const { src, pos } = state
+  if (src[pos] !== '$') return false
+
+  const addPending = (stt: string) => (state.pending += stt)
+  const found = (manipulation: () => void, newPos: number) => {
+    if (!silent) manipulation()
+    state.pos = newPos
+    return true
+  }
+
+  const start = pos + 1
+  if (!isValidDelim(state).openable) return found(() => addPending('$'), start)
+
+  let match = start
+  while ((match = src.indexOf('$', match)) !== -1) {
+    let dollarPos = match - 1
+    while (src[dollarPos] === '\\') dollarPos -= 1
+
+    if ((match - dollarPos) % 2 === 1) break
+    match += 1
+  }
+
+  if (match === -1) return found(() => addPending('$'), start)
+  if (match - start === 0) return found(() => addPending('$$'), start + 1)
+  if (!isValidDelim(state, match).closable) {
+    return found(() => addPending('$'), start)
+  }
+
+  return found(() => {
+    const token = state.push('math_inline', 'math', 0)
+    token.markup = '$'
+    token.content = src.slice(start, match)
+  }, match + 1)
+}
+
+function parseMathBlock(state, start, end, silent) {
+  const { blkIndent, bMarks, eMarks, src, tShift } = state
+  let pos = bMarks[start] + tShift[start]
+  let max = eMarks[start]
+
+  if (pos + 2 > max || src.slice(pos, pos + 2) !== '$$') return false
+  if (silent) return true
+
+  pos += 2
+
+  let firstLine = src.slice(pos, max)
+  let lastLine
+  let found = firstLine.trim().slice(-2) === '$$'
+
+  if (found) firstLine = firstLine.trim().slice(0, -2)
+
+  let next = start
+  for (; !found; ) {
+    next += 1
+    if (next >= end) break
+
+    pos = bMarks[next] + tShift[next]
+    max = eMarks[next]
+    if (pos < max && tShift[next] < blkIndent) break
+
+    const target = src.slice(pos, max).trim()
+
+    if (target.slice(-2) === '$$') {
+      found = true
+      lastLine = src.slice(pos, src.slice(0, max).lastIndexOf('$$'))
+    }
+  }
+
+  state.line = next + 1
+
+  const token = state.push('math_block', 'math', 0)
+  token.block = true
+  token.content = ''
+  token.map = [start, state.line]
+  token.markup = '$$'
+
+  if (firstLine && firstLine.trim()) token.content += `${firstLine}\n`
+  token.content += state.getLines(start + 1, next, tShift[start], true)
+  if (lastLine && lastLine.trim()) token.content += lastLine
+
+  return true
 }
 
 export function markdown(md, opts: {}, update: (to: boolean) => void): void {
@@ -37,22 +131,15 @@ export function markdown(md, opts: {}, update: (to: boolean) => void): void {
     if (!state.inlineMode) update(false)
   })
 
-  // Parse math syntax by using markdown-it-katex
-  md.use(markdownItKatex)
+  // Inline
+  md.inline.ruler.after('escape', 'marp_math_inline', (state, silent) => {
+    if (parseInlineMath(state, silent)) {
+      update(true)
+      return true
+    }
+    return false
+  })
 
-  for (const rule of Object.keys(rules)) {
-    const kind = rules[rule]
-    const original = md[kind].ruler.__rules__[md[kind].ruler.__find__(rule)].fn
-
-    md[kind].ruler.at(rule, (...args) => {
-      const ret = original(...args)
-      if (ret) update(true)
-
-      return ret
-    })
-  }
-
-  // Swap renderer to use the latest KaTeX
   md.renderer.rules.math_inline = (tokens, idx) => {
     const { content } = tokens[idx]
 
@@ -63,6 +150,22 @@ export function markdown(md, opts: {}, update: (to: boolean) => void): void {
       return content
     }
   }
+
+  // Block
+  md.block.ruler.after(
+    'blockquote',
+    'marp_math_block',
+    (state, start, end, silent) => {
+      if (parseMathBlock(state, start, end, silent)) {
+        update(true)
+        return true
+      }
+      return false
+    },
+    {
+      alt: ['paragraph', 'reference', 'blockquote', 'list'],
+    }
+  )
 
   md.renderer.rules.math_block = (tokens, idx) => {
     const { content } = tokens[idx]

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -1,3 +1,12 @@
+/**
+ * marp-core math plugin
+ *
+ * It is implemented based on markdown-it-katex plugin. It is no longer
+ * maintained by author, so we have ported math typesetting parser.
+ *
+ * @see https://github.com/waylonflinn/markdown-it-katex
+ */
+
 import katex from 'katex'
 import postcss from 'postcss'
 import katexScss from './katex.scss'
@@ -120,7 +129,11 @@ function parseMathBlock(state, start, end, silent) {
   return true
 }
 
-export function markdown(md, opts: {}, update: (to: boolean) => void): void {
+export function markdown(
+  md,
+  opts: {},
+  update: (rendered: boolean) => void = () => {}
+): void {
   const genOpts = (displayMode: boolean) => ({
     throwOnError: false,
     ...opts,

--- a/test/math/__snapshots__/math.ts.snap
+++ b/test/math/__snapshots__/math.ts.snap
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`markdown-it math plugin allows to place text immediately after inline math 1`] = `
+"<p><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mi>n</mi></mrow><annotation encoding=\\"application/x-tex\\">n</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.43056em;vertical-align:0em;\\"></span><span class=\\"mord mathdefault\\">n</span></span></span></span>-th order</p>
+"
+`;
+
+exports[`markdown-it math plugin can appear both maths in lists 1`] = `
+"<ul>
+<li><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">2</span></span></span></span></li>
+<li>
+<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2
+</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">2</span></span></span></span></span></p></li>
+</ul>
+"
+`;
+
+exports[`markdown-it math plugin does not allow paragraph break in inline math 1`] = `
+"<p>foo $1+1</p>
+<p>= 2$ bar</p>
+"
+`;
+
+exports[`markdown-it math plugin does not process apparent markup in inline math 1`] = `
+"<p>foo <span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mn>1</mn><mo>∗</mo><mi>i</mi><mo>∗</mo><mn>1</mn></mrow><annotation encoding=\\"application/x-tex\\">1 *i* 1</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">∗</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.65952em;vertical-align:0em;\\"></span><span class=\\"mord mathdefault\\">i</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">∗</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span></span></span></span> bar</p>
+"
+`;
+
+exports[`markdown-it math plugin does not recognize inline block math 1`] = `
+"<p>It's well know that $$1 + 1 = 3$$ for sufficiently large 1.</p>
+"
+`;
+
+exports[`markdown-it math plugin does not render block math with indented up to 4 spaces (code block) 1`] = `
+"<pre><code>$$
+1+1 = 2
+$$</code></pre>
+"
+`;
+
+exports[`markdown-it math plugin does not render math when delimiters are escaped 1`] = `
+"<p>Foo $1$ bar
+$$
+1
+$$</p>
+"
+`;
+
+exports[`markdown-it math plugin does not render math when numbers are followed closing inline math 1`] = `
+"<p>Thus, $20,000 and USD$30,000 won't parse as math.</p>
+"
+`;
+
+exports[`markdown-it math plugin does not render with empty content 1`] = `
+"<p>aaa $$ bbb</p>
+"
+`;
+
+exports[`markdown-it math plugin recognizes escaped delimiters in math mode 1`] = `
+"<p>Money adds: <span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mi mathvariant=\\"normal\\">$</mi><mi>X</mi><mo>+</mo><mi mathvariant=\\"normal\\">$</mi><mi>Y</mi><mo>=</mo><mi mathvariant=\\"normal\\">$</mi><mi>Z</mi></mrow><annotation encoding=\\"application/x-tex\\">\\\\$X + \\\\$Y = \\\\$Z</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.83333em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">$</span><span class=\\"mord mathdefault\\" style=\\"margin-right:0.07847em;\\">X</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.80556em;vertical-align:-0.05556em;\\"></span><span class=\\"mord\\">$</span><span class=\\"mord mathdefault\\" style=\\"margin-right:0.22222em;\\">Y</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.80556em;vertical-align:-0.05556em;\\"></span><span class=\\"mord\\">$</span><span class=\\"mord mathdefault\\" style=\\"margin-right:0.07153em;\\">Z</span></span></span></span>.</p>
+"
+`;
+
+exports[`markdown-it math plugin recognizes multiline escaped delimiters in math module 1`] = `
+"<p>Weird-o: <span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mstyle scriptlevel=\\"0\\" displaystyle=\\"true\\"><mrow><mo fence=\\"true\\">(</mo><mtable><mtr><mtd><mstyle scriptlevel=\\"0\\" displaystyle=\\"false\\"><mi mathvariant=\\"normal\\">$</mi></mstyle></mtd><mtd><mstyle scriptlevel=\\"0\\" displaystyle=\\"false\\"><mn>1</mn></mstyle></mtd></mtr><mtr><mtd><mstyle scriptlevel=\\"0\\" displaystyle=\\"false\\"><mi mathvariant=\\"normal\\">$</mi></mstyle></mtd></mtr></mtable><mo fence=\\"true\\">)</mo></mrow></mstyle></mrow><annotation encoding=\\"application/x-tex\\">\\\\displaystyle{\\\\begin{pmatrix} \\\\$ &amp; 1\\\\\\\\\\\\$ \\\\end{pmatrix}}</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:2.40003em;vertical-align:-0.95003em;\\"></span><span class=\\"mord\\"><span class=\\"minner\\"><span class=\\"mopen delimcenter\\" style=\\"top:0em;\\"><span class=\\"delimsizing size3\\">(</span></span><span class=\\"mord\\"><span class=\\"mtable\\"><span class=\\"col-align-c\\"><span class=\\"vlist-t vlist-t2\\"><span class=\\"vlist-r\\"><span class=\\"vlist\\" style=\\"height:1.45em;\\"><span style=\\"top:-3.61em;\\"><span class=\\"pstrut\\" style=\\"height:3em;\\"></span><span class=\\"mord\\"><span class=\\"mord\\">$</span></span></span><span style=\\"top:-2.4099999999999997em;\\"><span class=\\"pstrut\\" style=\\"height:3em;\\"></span><span class=\\"mord\\"><span class=\\"mord\\">$</span></span></span></span><span class=\\"vlist-s\\">​</span></span><span class=\\"vlist-r\\"><span class=\\"vlist\\" style=\\"height:0.9500000000000004em;\\"><span></span></span></span></span></span><span class=\\"arraycolsep\\" style=\\"width:0.5em;\\"></span><span class=\\"arraycolsep\\" style=\\"width:0.5em;\\"></span><span class=\\"col-align-c\\"><span class=\\"vlist-t\\"><span class=\\"vlist-r\\"><span class=\\"vlist\\" style=\\"height:1.45em;\\"><span style=\\"top:-3.61em;\\"><span class=\\"pstrut\\" style=\\"height:3em;\\"></span><span class=\\"mord\\"><span class=\\"mord\\">1</span></span></span></span></span></span></span></span></span><span class=\\"mclose delimcenter\\" style=\\"top:0em;\\"><span class=\\"delimsizing size3\\">)</span></span></span></span></span></span></span>.</p>
+"
+`;
+
+exports[`markdown-it math plugin renders block math composed multiple lines with starting/ending expression on delimited lines 1`] = `
+"<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mo>[</mo><mo>[</mo><mn>1</mn><mo separator=\\"true\\">,</mo><mn>2</mn><mo>]</mo><mo>[</mo><mn>3</mn><mo separator=\\"true\\">,</mo><mn>4</mn><mo>]</mo><mo>]</mo></mrow><annotation encoding=\\"application/x-tex\\">[
+[1, 2]
+[3, 4]
+]</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:1em;vertical-align:-0.25em;\\"></span><span class=\\"mopen\\">[</span><span class=\\"mopen\\">[</span><span class=\\"mord\\">1</span><span class=\\"mpunct\\">,</span><span class=\\"mspace\\" style=\\"margin-right:0.16666666666666666em;\\"></span><span class=\\"mord\\">2</span><span class=\\"mclose\\">]</span><span class=\\"mopen\\">[</span><span class=\\"mord\\">3</span><span class=\\"mpunct\\">,</span><span class=\\"mspace\\" style=\\"margin-right:0.16666666666666666em;\\"></span><span class=\\"mord\\">4</span><span class=\\"mclose\\">]</span><span class=\\"mclose\\">]</span></span></span></span></span></p>"
+`;
+
+exports[`markdown-it math plugin renders block math with indented up to 3 spaces 1`] = `
+"<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2
+</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">2</span></span></span></span></span></p>"
+`;
+
+exports[`markdown-it math plugin renders block math with self-closing at the end of document 1`] = `"<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">2</span></span></span></span></span></p>"`;
+
+exports[`markdown-it math plugin renders block math written in one line 1`] = `
+"<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2
+</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">2</span></span></span></span></span></p>"
+`;
+
+exports[`markdown-it math plugin renders math even when it starts with a negative sign 1`] = `
+"<p>foo<span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mo>−</mo><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>0</mn></mrow><annotation encoding=\\"application/x-tex\\">-1+1 = 0</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">−</span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">0</span></span></span></span>bar</p>
+"
+`;
+
+exports[`markdown-it math plugin renders math without whitespace before and after delimiter 1`] = `
+"<p>foo<span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">2</span></span></span></span>bar</p>
+"
+`;
+
+exports[`markdown-it math plugin renders multiline display math 1`] = `
+"<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">
+  1
++ 1
+
+= 2
+
+</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">2</span></span></span></span></span></p>"
+`;
+
+exports[`markdown-it math plugin renders multiline inline math 1`] = `
+"<p>foo <span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1 + 1
+= 2</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">2</span></span></span></span> bar</p>
+"
+`;
+
+exports[`markdown-it math plugin renders simple block math 1`] = `
+"<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2
+</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">2</span></span></span></span></span></p>"
+`;
+
+exports[`markdown-it math plugin renders simple inline math 1`] = `
+"<p><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">2</span></span></span></span></p>
+"
+`;
+
+exports[`markdown-it math plugin requires a closing delimiter to render math 1`] = `
+"<p>aaa $5.99 bbb</p>
+"
+`;
+
+exports[`markdown-it math plugin requires non whitespace to left of closing inline math 1`] = `
+"<p>I will give you $20 today, if you give me more $ tomorrow.</p>
+"
+`;
+
+exports[`markdown-it math plugin requires non whitespace to right of opening inline math 1`] = `
+"<p>For some Europeans, it is 2$ for a can of soda, not 1$.</p>
+"
+`;

--- a/test/math/math.ts
+++ b/test/math/math.ts
@@ -1,0 +1,172 @@
+/**
+ * All test cases are ported from markdown-it-katex.
+ *
+ * @see https://github.com/waylonflinn/markdown-it-katex/blob/master/test/fixtures/default.txt
+ */
+
+import MarkdownIt from 'markdown-it'
+import { markdown as mathPlugin } from '../../src/math/math'
+
+const countMath = stt => stt.split('class="katex"').length - 1
+const countBlockMath = stt => stt.split('class="katex-display"').length - 1
+
+describe('markdown-it math plugin', () => {
+  const md = new MarkdownIt().use(mathPlugin)
+
+  it('renders simple inline math', () => {
+    const rendered = md.render('$1+1 = 2$')
+    expect(countMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('renders simple block math', () => {
+    const rendered = md.render('$$1+1 = 2$$')
+    expect(countBlockMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('renders math without whitespace before and after delimiter', () => {
+    const rendered = md.render('foo$1+1 = 2$bar')
+    expect(countMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('renders math even when it starts with a negative sign', () => {
+    const rendered = md.render('foo$-1+1 = 0$bar')
+    expect(countMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('does not render with empty content', () => {
+    const rendered = md.render('aaa $$ bbb')
+    expect(countMath(rendered)).toBe(0)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('requires a closing delimiter to render math', () => {
+    const rendered = md.render('aaa $5.99 bbb')
+    expect(countMath(rendered)).toBe(0)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('does not allow paragraph break in inline math', () => {
+    const rendered = md.render('foo $1+1\n\n= 2$ bar')
+    expect(countMath(rendered)).toBe(0)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('does not process apparent markup in inline math', () => {
+    const rendered = md.render('foo $1 *i* 1$ bar')
+    expect(countMath(rendered)).toBe(1)
+    expect(rendered).not.toContain('<em>')
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('renders block math with indented up to 3 spaces', () => {
+    const rendered = md.render('   $$\n   1+1 = 2\n   $$')
+    expect(countBlockMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('does not render block math with indented up to 4 spaces (code block)', () => {
+    const rendered = md.render('    $$\n    1+1 = 2\n    $$')
+    expect(countBlockMath(rendered)).toBe(0)
+    expect(rendered).toContain('<code>')
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('renders multiline inline math', () => {
+    const rendered = md.render('foo $1 + 1\n= 2$ bar')
+    expect(countMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('renders multiline display math', () => {
+    const rendered = md.render('$$\n\n  1\n+ 1\n\n= 2\n\n$$')
+    expect(countBlockMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('allows to place text immediately after inline math', () => {
+    const rendered = md.render('$n$-th order')
+    expect(countMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('renders block math with self-closing at the end of document', () => {
+    const rendered = md.render('$$\n1+1 = 2')
+    expect(countBlockMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('can appear both maths in lists', () => {
+    const rendered = md.render('* $1+1 = 2$\n* $$\n  1+1 = 2\n  $$')
+    expect(countMath(rendered)).toBe(2)
+    expect(countBlockMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('renders block math written in one line', () => {
+    const rendered = md.render('$$1+1 = 2$$')
+    expect(countBlockMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('renders block math composed multiple lines with starting/ending expression on delimited lines', () => {
+    const rendered = md.render('$$[\n[1, 2]\n[3, 4]\n]$$')
+    expect(countBlockMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('does not render math when delimiters are escaped', () => {
+    const rendered = md.render('Foo \\$1$ bar\n\\$\\$\n1\n\\$\\$')
+    expect(countMath(rendered)).toBe(0)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('does not render math when numbers are followed closing inline math', () => {
+    const rendered = md.render(
+      "Thus, $20,000 and USD$30,000 won't parse as math."
+    )
+    expect(countMath(rendered)).toBe(0)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('requires non whitespace to right of opening inline math', () => {
+    const rendered = md.render(
+      'For some Europeans, it is 2$ for a can of soda, not 1$.'
+    )
+    expect(countMath(rendered)).toBe(0)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('requires non whitespace to left of closing inline math', () => {
+    const rendered = md.render(
+      'I will give you $20 today, if you give me more $ tomorrow.'
+    )
+    expect(countMath(rendered)).toBe(0)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('does not recognize inline block math', () => {
+    const rendered = md.render(
+      "It's well know that $$1 + 1 = 3$$ for sufficiently large 1."
+    )
+    expect(countMath(rendered)).toBe(0)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('recognizes escaped delimiters in math mode', () => {
+    const rendered = md.render('Money adds: $\\$X + \\$Y = \\$Z$.')
+    expect(countMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('recognizes multiline escaped delimiters in math module', () => {
+    const rendered = md.render(
+      'Weird-o: $\\displaystyle{\\begin{pmatrix} \\$ & 1\\\\\\$ \\end{pmatrix}}$.'
+    )
+    expect(countMath(rendered)).toBe(1)
+    expect(rendered).toMatchSnapshot()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3591,7 +3591,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-katex@^0.10.0, katex@^0.6.0:
+katex@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/katex/-/katex-0.10.0.tgz#da562e5d0d5cc3aa602e27af8a9b8710bfbce765"
   integrity sha512-/WRvx+L1eVBrLwX7QzKU1dQuaGnE7E8hDvx3VWfZh9HbMiCfsKWJNnYZ0S8ZMDAfAyDSofdyXIrH/hujF1fYXg==
@@ -3843,13 +3843,6 @@ markdown-it-front-matter@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/markdown-it-front-matter/-/markdown-it-front-matter-0.1.2.tgz#e50bf56e77e6a4f5ac4ffa894d4d45ccd9896b20"
   integrity sha1-5Qv1bnfmpPWsT/qJTU1FzNmJayA=
-
-markdown-it-katex@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/markdown-it-katex/-/markdown-it-katex-2.0.3.tgz#d7b86a1aea0b9d6496fab4e7919a18fdef589c39"
-  integrity sha1-17hqGuoLnWSW+rTnkZoY/e9YnDk=
-  dependencies:
-    katex "^0.6.0"
 
 markdown-it@^8.4.2:
   version "8.4.2"


### PR DESCRIPTION
We ported math typesetting syntax parsers for inline (`$`) and block (`$$`) from markdown-it-katex (not maintained).

It includes some optimizations while porting code, but the logic of parser is not changed. We also have ported test cases, using Jest's snapshot test. We should keep the original behavior about math typesettings.

markdown-it-katex is removed from dependencies, so developer using marp-core must not worry about double-bundling katex anymore.

Resolve #47.
