### PR TITLE
Mark Marp.options member as readonly

### DIFF
--- a/src/marp.ts
+++ b/src/marp.ts
@@ -25,7 +25,7 @@ export interface MarpOptions extends MarpitOptions {
 }
 
 export class Marp extends Marpit {
-  options!: MarpOptions
+  readonly options!: MarpOptions
 
   private renderedMath: boolean = false
 


### PR DESCRIPTION
Unlike Marpit, Marp class allows to modify `options` member. This PR will mark it as readonly.