### PR TITLE
Colored strong element in headings for highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Colored `<strong>` element in headings for highlighting ([#59](https://github.com/marp-team/marp-core/pull/59))
+
 ## v0.4.1 - 2018-12-31
 
 ### Fixed

--- a/themes/default.scss
+++ b/themes/default.scss
@@ -38,6 +38,17 @@ h6 {
   font-size: 0.9em;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  strong {
+    color: #48c;
+  }
+}
+
 hr {
   height: 0;
   padding-top: 0.25em;
@@ -134,6 +145,17 @@ section {
     blockquote {
       border-color: #3d3f43;
       color: #939699;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      strong {
+        color: #7bf;
+      }
     }
 
     hr {

--- a/themes/default.scss
+++ b/themes/default.scss
@@ -45,6 +45,7 @@ h4,
 h5,
 h6 {
   strong {
+    font-weight: inherit;
     color: #48c;
   }
 }

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -81,6 +81,10 @@ h4,
 h5,
 h6 {
   margin: 0.5em 0 0 0;
+
+  strong {
+    font-weight: inherit;
+  }
 }
 
 h1 {

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -27,6 +27,17 @@ $color-secondary: #81d4fa;
     color: $bg;
   }
 
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    strong {
+      color: $highlight;
+    }
+  }
+
   pre > code {
     background: $text;
   }

--- a/themes/uncover.scss
+++ b/themes/uncover.scss
@@ -120,6 +120,10 @@ section {
   h5,
   h6 {
     margin: 15px 0 30px 0;
+
+    strong {
+      font-weight: inherit;
+    }
   }
 
   h1 {

--- a/themes/uncover.scss
+++ b/themes/uncover.scss
@@ -30,6 +30,17 @@
     }
   }
 
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    strong {
+      color: mix(#fff, $highlight, 20%);
+    }
+  }
+
   header,
   footer {
     color: rgba($text, 0.4);


### PR DESCRIPTION
Update theme CSS to support highlighting text in header through `**strong**`. 

```markdown
# Support **highlighting**
```

||Default|Gaia|Uncover|
|:---:|:---:|:---:|:---:|
|**`default`**|![screenshot_2019-01-12 screenshot](https://user-images.githubusercontent.com/3993388/51072489-ee4d4600-16a4-11e9-95c5-3593a6600d58.png)|![screenshot_2019-01-12 screenshot 2](https://user-images.githubusercontent.com/3993388/51072494-002ee900-16a5-11e9-9463-61952ef0e7e2.png)|![screenshot_2019-01-12 screenshot 5](https://user-images.githubusercontent.com/3993388/51072497-058c3380-16a5-11e9-8f2a-1268c345d816.png)|
|**`invert`**|![screenshot_2019-01-12 screenshot 1](https://user-images.githubusercontent.com/3993388/51072501-0f159b80-16a5-11e9-8a6e-1943ac9fd0aa.png)|![screenshot_2019-01-12 screenshot 3](https://user-images.githubusercontent.com/3993388/51072502-1177f580-16a5-11e9-85ce-170c17c6b1ad.png)|![screenshot_2019-01-12 screenshot 6](https://user-images.githubusercontent.com/3993388/51072503-1472e600-16a5-11e9-9f9c-ab358e4e534a.png)|
|**`gaia`**||![screenshot_2019-01-12 screenshot 4](https://user-images.githubusercontent.com/3993388/51072504-19379a00-16a5-11e9-94b9-7f2d6ea97d72.png)||

Typically the headings has a bold text by browser default style, so `<strong>` element by `**this markup**` would not affect to the rendering of headings. Therefore, the custom style for `<strong>` in headings would be allowed.

The [pre-released Marp](https://github.com/yhatt/marp) already has a `==markup==` for highlighting, but we have not adopted because it is against CommonMark. The added style can use as the alternative of it.