### PR TITLE
Prevent showing scrollbar in code element

### DIFF
--- a/themes/default.scss
+++ b/themes/default.scss
@@ -58,6 +58,7 @@ hr {
 pre {
   border: 1px solid #999;
   line-height: 1.15;
+  overflow: visible;
 
   code svg[data-marp-fitting='svg'] {
     // Slide height - padding * 2 - code's padding * 3 - code's border * 2

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -141,7 +141,7 @@ pre {
   display: block;
   margin: 1em 0 0 0;
   min-height: 1em;
-  overflow: auto;
+  overflow: visible;
 
   code {
     box-sizing: border-box;


### PR DESCRIPTION
Marp Core is already supported auto scaling for code. However, default theme that has based on GitHub styling is assigned `overflow: auto` style to code. So sometimes it would appear scrollbars in code.

It means that not-working scrollbar is appeared in exported PDF. In fact, this behavior made confusion to user. See: https://stackoverflow.com/questions/44660044/markdown-to-pdf-and-scrollbars

In theory, we not have to use scrollbars in auto-scaled code. Thus, we added `overflow: visible` style to `<pre>`.