### PR TITLE
Support an enhanced Marpit enable state

### DIFF
--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -2,6 +2,7 @@ import emojiRegex from 'emoji-regex'
 import Token from 'markdown-it/lib/token'
 import markdownItEmoji from 'markdown-it-emoji'
 import twemoji from 'twemoji'
+import { marpEnabledSymbol } from '../marp'
 import twemojiCSS from './twemoji.scss'
 
 export interface EmojiOptions {
@@ -56,7 +57,7 @@ export function markdown(md, opts: EmojiOptions): void {
                           Object.assign(new Token(), {
                             ...t,
                             content: text,
-                            type: idx % 2 ? 'unicode_emoji' : 'text',
+                            type: idx % 2 ? 'marp_unicode_emoji' : 'text',
                           }),
                         ],
                   []
@@ -72,28 +73,32 @@ export function markdown(md, opts: EmojiOptions): void {
       }
     })
 
-    md.renderer.rules.unicode_emoji = (token: any[], idx: number): string =>
-      token[idx].content
+    md.renderer.rules.marp_unicode_emoji = (
+      token: any[],
+      idx: number
+    ): string => token[idx].content
 
     const { code_block, code_inline, fence } = md.renderer.rules
 
     if (opts.unicode === 'twemoji') {
       const wrap = text =>
-        text
-          .split(/(<[^>]*>)/g)
-          .reduce(
-            (ret, part, idx) =>
-              `${ret}${
-                idx % 2
-                  ? part
-                  : part.replace(regexForSplit, ([emoji]) =>
-                      twemojiParse(emoji)
-                    )
-              }`,
-            ''
-          )
+        md[marpEnabledSymbol]
+          ? text
+              .split(/(<[^>]*>)/g)
+              .reduce(
+                (ret, part, idx) =>
+                  `${ret}${
+                    idx % 2
+                      ? part
+                      : part.replace(regexForSplit, ([emoji]) =>
+                          twemojiParse(emoji)
+                        )
+                  }`,
+                ''
+              )
+          : text
 
-      md.renderer.rules.unicode_emoji = twemojiRenderer
+      md.renderer.rules.marp_unicode_emoji = twemojiRenderer
 
       md.renderer.rules.code_inline = (...args) => wrap(code_inline(...args))
       md.renderer.rules.code_block = (...args) => wrap(code_block(...args))

--- a/src/html/html.ts
+++ b/src/html/html.ts
@@ -1,13 +1,16 @@
 import { FilterXSS } from 'xss'
-import { MarpOptions } from '../marp'
+import { MarpOptions, marpEnabledSymbol } from '../marp'
 
 export function markdown(md, opts: MarpOptions['html']): void {
   if (typeof opts === 'object') {
     const { html_inline, html_block } = md.renderer.rules
     const filter = new FilterXSS({ whiteList: opts })
 
-    const sanitizedRenderer = original => (...args) =>
-      filter.process(original(...args))
+    const sanitizedRenderer = (original: Function) => (...args) => {
+      const ret = original(...args)
+
+      return md[marpEnabledSymbol] ? filter.process(ret) : ret
+    }
 
     md.renderer.rules.html_inline = sanitizedRenderer(html_inline)
     md.renderer.rules.html_block = sanitizedRenderer(html_block)

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -25,7 +25,7 @@ export interface MarpOptions extends MarpitOptions {
 }
 
 export class Marp extends Marpit {
-  readonly options!: MarpOptions
+  readonly options!: Required<MarpOptions>
 
   private renderedMath: boolean = false
 
@@ -74,10 +74,10 @@ export class Marp extends Marpit {
     const { emoji, html, math } = this.options
 
     // HTML sanitizer
-    md.use(htmlPlugin.markdown, html)
+    this.use(htmlPlugin.markdown, html)
 
     // Emoji support
-    md.use(emojiPlugin.markdown, emoji)
+    this.use(emojiPlugin.markdown, emoji)
 
     // Math typesetting
     if (math) {
@@ -86,14 +86,15 @@ export class Marp extends Marpit {
           ? math.katexOption
           : {}
 
-      md.use(mathPlugin.markdown, opts, flag => (this.renderedMath = flag))
+      this.use(mathPlugin.markdown, opts, flag => (this.renderedMath = flag))
     }
 
     // Fitting
-    const themeResolver: fittingPlugin.ThemeResolver = () =>
-      (this.lastGlobalDirectives || {}).theme
-
-    md.use(fittingPlugin.markdown, this, themeResolver)
+    this.use(
+      fittingPlugin.markdown,
+      this,
+      () => (this.lastGlobalDirectives || {}).theme
+    )
   }
 
   highlighter(code: string, lang: string): string {
@@ -107,13 +108,11 @@ export class Marp extends Marpit {
 
   protected themeSetPackOptions(): ThemeSetPackOptions {
     const base = { ...super.themeSetPackOptions() }
-    const prependCSS = css => {
-      if (css) base.before = `${css}\n${base.before || ''}`
-    }
+    const prepend = css => css && (base.before = `${css}\n${base.before || ''}`)
     const { emoji, math } = this.options
 
-    prependCSS(emojiPlugin.css(emoji!))
-    prependCSS(fittingPlugin.css)
+    prepend(emojiPlugin.css(emoji!))
+    prepend(fittingPlugin.css)
 
     if (math && this.renderedMath) {
       // By default, we use KaTeX web fonts through CDN.
@@ -126,7 +125,7 @@ export class Marp extends Marpit {
       }
 
       // Add KaTeX css
-      prependCSS(mathPlugin.css(path))
+      prepend(mathPlugin.css(path))
     }
 
     return base

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -37,7 +37,7 @@ export function markdown(
     return false
   })
 
-  md.renderer.rules.math_inline = (tokens, idx) => {
+  md.renderer.rules.marp_math_inline = (tokens, idx) => {
     const { content } = tokens[idx]
 
     try {
@@ -64,7 +64,7 @@ export function markdown(
     }
   )
 
-  md.renderer.rules.math_block = (tokens, idx) => {
+  md.renderer.rules.marp_math_block = (tokens, idx) => {
     const { content } = tokens[idx]
 
     try {
@@ -137,7 +137,7 @@ function parseInlineMath(state, silent) {
   }
 
   return found(() => {
-    const token = state.push('math_inline', 'math', 0)
+    const token = state.push('marp_math_inline', 'math', 0)
     token.markup = '$'
     token.content = src.slice(start, match)
   }, match + 1)
@@ -178,7 +178,7 @@ function parseMathBlock(state, start, end, silent) {
 
   state.line = next + 1
 
-  const token = state.push('math_block', 'math', 0)
+  const token = state.push('marp_math_block', 'math', 0)
   token.block = true
   token.content = ''
   token.map = [start, state.line]


### PR DESCRIPTION
Marp Core should support an enhanced Marpit enable state, provided by [Marpit v0.7.0](https://github.com/marp-team/marpit/releases/tag/v0.7.0). `StateCore.marpit(false)` in core rule can disable Marp features together with Marpit now.

We also added a trick to track enable state to decide whether rendering extended mark up in the renderer added by Marp Core. When Marpit state is disabled, we should render as if not using Marpit and Marp Core.

In addition, a few tokens have prefixed `marp_` to prevent the collision between other plugins.

We're working this to support switching Markdown preview and Marp slide deck preview in planned Marp VSCode plugin. (yhatt/marp#118)