### PR TITLE
Fix circular dependency and error in build

### DIFF
--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -2,7 +2,7 @@ import emojiRegex from 'emoji-regex'
 import Token from 'markdown-it/lib/token'
 import markdownItEmoji from 'markdown-it-emoji'
 import twemoji from 'twemoji'
-import { marpEnabledSymbol } from '../marp'
+import { marpEnabledSymbol } from '../symbol'
 import twemojiCSS from './twemoji.scss'
 
 export interface EmojiOptions {

--- a/src/fitting/fitting.ts
+++ b/src/fitting/fitting.ts
@@ -1,6 +1,7 @@
 import Token from 'markdown-it/lib/token'
 import fittingCSS from './fitting.scss'
-import { Marp, marpEnabledSymbol } from '../marp'
+import { Marp } from '../marp'
+import { marpEnabledSymbol } from '../symbol'
 
 export const css = fittingCSS
 export const attr = 'data-marp-fitting'

--- a/src/html/html.ts
+++ b/src/html/html.ts
@@ -1,5 +1,6 @@
 import { FilterXSS } from 'xss'
-import { MarpOptions, marpEnabledSymbol } from '../marp'
+import { MarpOptions } from '../marp'
+import { marpEnabledSymbol } from '../symbol'
 
 export function markdown(md, opts: MarpOptions['html']): void {
   if (typeof opts === 'object') {

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -2,6 +2,7 @@ import { Marpit, MarpitOptions, ThemeSetPackOptions } from '@marp-team/marpit'
 import highlightjs from 'highlight.js'
 import { version } from 'katex/package.json'
 import browser from './browser'
+import { marpEnabledSymbol } from './symbol'
 import * as emojiPlugin from './emoji/emoji'
 import * as fittingPlugin from './fitting/fitting'
 import * as htmlPlugin from './html/html'
@@ -23,8 +24,6 @@ export interface MarpOptions extends MarpitOptions {
 }
 
 const marpObservedSymbol = Symbol('marpObserved')
-
-export const marpEnabledSymbol = Symbol('marpEnabled')
 
 export class Marp extends Marpit {
   readonly options!: Required<MarpOptions>

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -1,0 +1,1 @@
+export const marpEnabledSymbol = Symbol('marpEnabled')

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -4,8 +4,9 @@ import MarkdownIt from 'markdown-it'
 import postcss from 'postcss'
 import context from './_helpers/context'
 import { EmojiOptions } from '../src/emoji/emoji'
-import { Marp, MarpOptions, marpEnabledSymbol } from '../src/marp'
 import browser from '../src/browser'
+import { Marp, MarpOptions } from '../src/marp'
+import { marpEnabledSymbol } from '../src/symbol'
 
 const marpitDisablePlugin = md =>
   md.core.ruler.before('normalize', 'disable', sc => sc.marpit(false))


### PR DESCRIPTION
#64 causes build error by `yarn build`.

```
$ yarn --silent clean && rollup -c

src/marp.ts → lib/marp.js...
(!) Circular dependency: src/marp.ts -> src/browser.ts -> src/fitting/observer.ts -> src/fitting/fitting.ts -> src/marp.ts
(!) Circular dependency: src/marp.ts -> src/emoji/emoji.ts -> src/marp.ts
(!) Circular dependency: src/marp.ts -> src/html/html.ts -> src/marp.ts
created lib/marp.js in 2.7s

browser.js → lib/browser.js...
(!) node-resolve plugin: preferring built-in module 'punycode' over local alternative at '/Users/yuki.hattori/Programs/personal/marp-core/node_modules/punycode/punycode.es6.js', pass 'preferBuiltins: false' to disable this behavior or 'preferBuiltins: true' to disable this warning
[!] (commonjs plugin) TypeError: Cannot read property 'warn' of undefined
TypeError: Cannot read property 'warn' of undefined
    at /Users/yuki.hattori/marp-core/node_modules/rollup-plugin-node-resolve/dist/rollup-plugin-node-resolve.cjs.js:186:16
```