### PR TITLE
Normalize known self-closing HTML elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Normalize known self-closing HTML elements with `xhtmlOut: true` ([#66](https://github.com/marp-team/marp-core/pull/66))
+
 ## v0.5.2 - 2019-01-31
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "rollup-plugin-postcss": "^2.0.1",
     "rollup-plugin-terser": "^4.0.3",
     "rollup-plugin-typescript": "^1.0.0",
+    "self-closing-tags": "^1.0.1",
     "stylelint": "^9.10.1",
     "stylelint-config-prettier": "^4.0.0",
     "stylelint-config-standard": "^18.2.0",

--- a/src/html/html.ts
+++ b/src/html/html.ts
@@ -3,32 +3,34 @@ import { FilterXSS } from 'xss'
 import { MarpOptions } from '../marp'
 import { marpEnabledSymbol } from '../symbol'
 
+const selfClosingRegexp = /\s*\/?>$/
+
 export function markdown(md, opts: MarpOptions['html']): void {
-  if (typeof opts === 'object') {
-    const { html_inline, html_block } = md.renderer.rules
-
-    const filter = new FilterXSS({ whiteList: opts })
-    const xhtmlOutFilter = new FilterXSS({
-      onTag: (tag, html, { isWhite, isClosing }: any) => {
-        if (isWhite && selfClosingTags.includes(tag)) {
-          let voidHtml = `<${html.slice(isClosing ? 2 : 1, -1)}`
-          if (!voidHtml.endsWith('/')) voidHtml += ' /'
-
-          return `${voidHtml}>`
-        }
-      },
-      whiteList: opts,
-    })
-
-    const sanitizedRenderer = (original: Function) => (...args) => {
-      const ret = original(...args)
-      if (!md[marpEnabledSymbol]) return ret
-
-      const sanitized = filter.process(ret)
-      return md.options.xhtmlOut ? xhtmlOutFilter.process(sanitized) : sanitized
-    }
-
-    md.renderer.rules.html_inline = sanitizedRenderer(html_inline)
-    md.renderer.rules.html_block = sanitizedRenderer(html_block)
+  const filterOpts = {
+    onIgnoreTag: (_, html) => (opts === true ? html : undefined),
+    whiteList: typeof opts === 'object' ? opts : {},
   }
+  const filter = new FilterXSS(filterOpts)
+  const xhtmlOutFilter = new FilterXSS({
+    ...filterOpts,
+    onTag: (tag, html, { isClosing }: any) => {
+      if (selfClosingTags.includes(tag)) {
+        const attrs = html.slice(tag.length + (isClosing ? 2 : 1), -1).trim()
+        return `<${tag} ${attrs}>`.replace(selfClosingRegexp, ' />')
+      }
+    },
+  })
+
+  const { html_inline, html_block } = md.renderer.rules
+
+  const sanitizedRenderer = (original: Function) => (...args) => {
+    const ret = original(...args)
+    if (!md[marpEnabledSymbol]) return ret
+
+    const sanitized = filter.process(ret)
+    return md.options.xhtmlOut ? xhtmlOutFilter.process(sanitized) : sanitized
+  }
+
+  md.renderer.rules.html_inline = sanitizedRenderer(html_inline)
+  md.renderer.rules.html_block = sanitizedRenderer(html_block)
 }

--- a/src/html/html.ts
+++ b/src/html/html.ts
@@ -1,3 +1,4 @@
+import selfClosingTags from 'self-closing-tags'
 import { FilterXSS } from 'xss'
 import { MarpOptions } from '../marp'
 import { marpEnabledSymbol } from '../symbol'
@@ -5,12 +6,26 @@ import { marpEnabledSymbol } from '../symbol'
 export function markdown(md, opts: MarpOptions['html']): void {
   if (typeof opts === 'object') {
     const { html_inline, html_block } = md.renderer.rules
+
     const filter = new FilterXSS({ whiteList: opts })
+    const xhtmlOutFilter = new FilterXSS({
+      onTag: (tag, html, { isWhite, isClosing }: any) => {
+        if (isWhite && selfClosingTags.includes(tag)) {
+          let voidHtml = `<${html.slice(isClosing ? 2 : 1, -1)}`
+          if (!voidHtml.endsWith('/')) voidHtml += ' /'
+
+          return `${voidHtml}>`
+        }
+      },
+      whiteList: opts,
+    })
 
     const sanitizedRenderer = (original: Function) => (...args) => {
       const ret = original(...args)
+      if (!md[marpEnabledSymbol]) return ret
 
-      return md[marpEnabledSymbol] ? filter.process(ret) : ret
+      const sanitized = filter.process(ret)
+      return md.options.xhtmlOut ? xhtmlOutFilter.process(sanitized) : sanitized
     }
 
     md.renderer.rules.html_inline = sanitizedRenderer(html_inline)

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -202,7 +202,7 @@ describe('Marp', () => {
       const m = marp({ html: true })
 
       it('allows HTML tag', () => {
-        const { html } = m.render('<b  data-custom="test">abc</b>')
+        const { html } = m.render('<b data-custom="test">abc</b>')
         expect(cheerio.load(html)('b[data-custom="test"]')).toHaveLength(1)
       })
 
@@ -213,7 +213,7 @@ describe('Marp', () => {
         expect(m.render('<br />').html).toContain('<br />')
         expect(m.render('<br></br>').html).toContain('<br /><br />')
         expect(m.render('<BR >').html).toContain('<br />')
-        expect(m.render('<br class="normalize">').html).toContain(
+        expect(m.render('<br  class="normalize">').html).toContain(
           '<br class="normalize" />'
         )
       })
@@ -260,10 +260,12 @@ describe('Marp', () => {
       const instance = marp().use(marpitDisablePlugin)
 
       it('does not sanitize HTML', () => {
-        const { html } = instance.render('<b>abc</b>\n\n<div>\ntest\n</div>')
+        const { html } = instance.render(
+          '<b data-custom="test">abc</b>\n\n<div>\ntest\n</div>'
+        )
         const $ = cheerio.load(html)
 
-        expect($('b')).toHaveLength(1)
+        expect($('b[data-custom="test"]')).toHaveLength(1)
         expect($('div')).toHaveLength(1)
       })
     })

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -199,9 +199,23 @@ describe('Marp', () => {
     })
 
     context('with true', () => {
+      const m = marp({ html: true })
+
       it('allows HTML tag', () => {
-        const { html } = marp({ html: true }).render('<b>abc</b>')
-        expect(cheerio.load(html)('b')).toHaveLength(1)
+        const { html } = m.render('<b  data-custom="test">abc</b>')
+        expect(cheerio.load(html)('b[data-custom="test"]')).toHaveLength(1)
+      })
+
+      it('renders void element with normalized', () => {
+        expect(m.render('<br>').html).toContain('<br />')
+        expect(m.render('<br  >').html).toContain('<br />')
+        expect(m.render('<br/>').html).toContain('<br />')
+        expect(m.render('<br />').html).toContain('<br />')
+        expect(m.render('<br></br>').html).toContain('<br /><br />')
+        expect(m.render('<BR >').html).toContain('<br />')
+        expect(m.render('<br class="normalize">').html).toContain(
+          '<br class="normalize" />'
+        )
       })
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5598,6 +5598,11 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
+self-closing-tags@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/self-closing-tags/-/self-closing-tags-1.0.1.tgz#6c5fa497994bb826b484216916371accee490a5d"
+  integrity sha512-7t6hNbYMxM+VHXTgJmxwgZgLGktuXtVVD5AivWzNTdJBM4DBjnDKDzkf2SrNjihaArpeJYNjxkELBu1evI4lQA==
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"


### PR DESCRIPTION
For normalize known self-closing HTML elements, we will apply multi-pass filtering to HTML renderer. When markdown-it's `xhtmlOut` option is `true`, the whitelisted HTML elements would be normalized.

### Motivation

I'm trying to enhance Marp's collaboration with well-known JavaScript framework: React, Vue, and so on. 

I have already tried using [Incremental DOM] via my [markdown-it-incremental-dom] plugin, and it works well at [Marp Web] built on [Preact]. However, these are not very well known although great modules. To spread Marp ecosystem widely, I'm thinking that we should provide a better experience into frequently used JS frameworks in general.

[Incremental DOM]: https://github.com/google/incremental-dom
[markdown-it-incremental-dom]: https://github.com/yhatt/markdown-it-incremental-dom
[Marp Web]: https://web.marp.app
[Preact]: https://preactjs.com/

So I have tried creating React component at my CodeSandbox: **https://codesandbox.io/s/v6v4rzx4jl**. It has succeeded to render slides with minimum diff by converting rendered HTML into virtual DOM (using [htm], [he], and [style-to-object]).

[htm]: https://github.com/developit/htm
[he]: https://github.com/mathiasbynens/he
[style-to-object]: https://github.com/remarkablemark/style-to-object

The problem was caused by the whitelisted `<br>` HTML element. htm parser requires the strict syntax to self-closing element, so user-written `<br>` will raise error. Thus, we have to normalize self-closing element.