### PR TITLE
Allow using twemoji via png by added emoji.twemoji.ext option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Allow using twemoji via PNG by added `emoji.twemoji.ext` option ([#67](https://github.com/marp-team/marp-core/pull/67))
+
 ### Changed
 
 - Normalize known self-closing HTML elements with `xhtmlOut: true` ([#66](https://github.com/marp-team/marp-core/pull/66))
+
+### Deprecated
+
+- `emoji.twemojiBase` option has soft-deprecated in favor of `emoji.twemoji.base` ([#67](https://github.com/marp-team/marp-core/pull/67))
 
 ## v0.5.2 - 2019-01-31
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ const marp = new Marp({
   emoji: {
     shortcode: true,
     unicode: false,
-    twemojiBase: '/resources/twemoji/',
+    twemoji: {
+      base: '/resources/twemoji/',
+    },
   },
   math: {
     katexFontPath: '/resources/fonts/',
@@ -221,9 +223,10 @@ Setting about emoji conversions.
   - It can convert Unicode emoji into twemoji when setting `"twemoji"`. 🐶 → <img src="https://twemoji.maxcdn.com/2/svg/1f436.svg" alt="🐶" width="16" height="16" valign="middle" /> _(default)_
   - If you not want this aggressive conversion, please set `false`.
 
-- **`twemojiBase`**: _`string`_
+- **`twemoji`**: _`object`_
 
-  - It is corresponded to [twemoji's `base` option](https://github.com/twitter/twemoji#object-as-parameter). By default, marp-core will use online emoji images [through MaxCDN (twemoji's default)](https://github.com/twitter/twemoji#cdn-support).
+  - **`base`**: _`string`_ - It is corresponded to [twemoji's `base` option](https://github.com/twitter/twemoji#object-as-parameter). By default, marp-core will use online emoji images [through MaxCDN (twemoji's default)](https://github.com/twitter/twemoji#cdn-support).
+  - **`ext`**: _`"svg"` | `"png"`_ - Setting the file type of twemoji images. _(`svg` by default)_
 
 > **For developers:** When you setting `unicode` option as `true`, Markdown parser will convert Unicode emoji into tokens internally. The rendering result is same as in `false`.
 

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -1,5 +1,4 @@
 import emojiRegex from 'emoji-regex'
-import Token from 'markdown-it/lib/token'
 import markdownItEmoji from 'markdown-it-emoji'
 import twemoji from 'twemoji'
 import { marpEnabledSymbol } from '../symbol'
@@ -71,7 +70,7 @@ export function markdown(md, opts: EmojiOptions): void {
   }
 
   if (opts.unicode) {
-    md.core.ruler.after('inline', 'marp_unicode_emoji', ({ tokens }) => {
+    md.core.ruler.after('inline', 'marp_unicode_emoji', ({ tokens, Token }) => {
       for (const token of tokens) {
         if (token.type === 'inline') {
           const newChildren: any[] = []

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -34,9 +34,7 @@ export function markdown(md, opts: EmojiOptions): void {
     twemoji.parse(content, {
       attributes: () => ({ 'data-marp-twemoji': '' }),
       base:
-        opts.twemojiBase ||
-        (twemojiOpts && twemojiOpts.base) ||
-        'https://twemoji.maxcdn.com/2/',
+        twemojiOpts.base || opts.twemojiBase || 'https://twemoji.maxcdn.com/2/',
       ext: `.${twemojiExt}`,
       size: twemojiExt === 'svg' ? 'svg' : 72,
     })

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -10,7 +10,7 @@ export interface EmojiOptions {
   twemoji?: TwemojiOptions
   unicode?: boolean | 'twemoji'
 
-  /** @deprecated */
+  /** @deprecated Use `twemoji.base` instead. */
   twemojiBase?: string
 }
 

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -7,8 +7,16 @@ import twemojiCSS from './twemoji.scss'
 
 export interface EmojiOptions {
   shortcode?: boolean | 'twemoji'
-  twemojiBase?: string
+  twemoji?: TwemojiOptions
   unicode?: boolean | 'twemoji'
+
+  /** @deprecated */
+  twemojiBase?: string
+}
+
+interface TwemojiOptions {
+  base?: string
+  ext?: 'svg' | 'png'
 }
 
 const regexForSplit = new RegExp(`(${emojiRegex().source})`, 'g')
@@ -19,15 +27,19 @@ export const css = (opts: EmojiOptions) =>
     : undefined
 
 export function markdown(md, opts: EmojiOptions): void {
+  const twemojiOpts = opts.twemoji || {}
+  const twemojiExt = twemojiOpts.ext || 'svg'
+
   const twemojiParse = (content: string): string =>
-    twemoji
-      .parse(content, {
-        base: opts.twemojiBase,
-        className: '__placeholder__',
-        ext: '.svg',
-        size: 'svg',
-      })
-      .replace('class="__placeholder__"', 'data-marp-twemoji')
+    twemoji.parse(content, {
+      attributes: () => ({ 'data-marp-twemoji': '' }),
+      base:
+        opts.twemojiBase ||
+        (twemojiOpts && twemojiOpts.base) ||
+        'https://twemoji.maxcdn.com/2/',
+      ext: `.${twemojiExt}`,
+      size: twemojiExt === 'svg' ? 'svg' : 72,
+    })
 
   const twemojiRenderer = (token: any[], idx: number): string =>
     twemojiParse(token[idx].content)

--- a/src/fitting/fitting.ts
+++ b/src/fitting/fitting.ts
@@ -1,4 +1,3 @@
-import Token from 'markdown-it/lib/token'
 import fittingCSS from './fitting.scss'
 import { Marp } from '../marp'
 import { marpEnabledSymbol } from '../symbol'
@@ -12,11 +11,11 @@ export const svgContentWrapAttr = 'data-marp-fitting-svg-content-wrap'
 
 export type ThemeResolver = () => string | undefined
 
-function wrapTokensByFittingToken(tokens: any[]): any[] {
-  const open = new Token('marp_fitting_open', 'span', 1)
+function wrapTokensByFittingToken(token, tokens: any[]): any[] {
+  const open = new token('marp_fitting_open', 'span', 1)
   open.attrSet(attr, 'plain')
 
-  return [open, ...tokens, new Token('marp_fitting_close', 'span', -1)]
+  return [open, ...tokens, new token('marp_fitting_close', 'span', -1)]
 }
 
 // Wrap code block and fence renderer by fitting elements.
@@ -70,7 +69,10 @@ function fittingHeader(md, marp: Marp): void {
           }
 
           if (requireWrapping) {
-            token.children = wrapTokensByFittingToken(token.children)
+            token.children = wrapTokensByFittingToken(
+              state.Token,
+              token.children
+            )
           }
         } else if (token.type === 'heading_close') {
           target = undefined

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -54,7 +54,6 @@ export class Marp extends Marpit {
       ],
       emoji: {
         shortcode: 'twemoji',
-        twemojiBase: undefined,
         unicode: 'twemoji',
         ...(opts.emoji || {}),
       },

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -132,15 +132,34 @@ describe('Marp', () => {
       })
     })
 
-    describe('twemojiBase option', () => {
-      const instance = (emoji: EmojiOptions = {}) => new Marp({ emoji })
+    describe('twemoji option', () => {
+      const instance = (twemoji: EmojiOptions['twemoji'] = {}) =>
+        new Marp({ emoji: { twemoji } })
 
-      it('uses twemoji CDN by default', () => {
+      it('uses SVG via twemoji CDN by default', () => {
         const $ = cheerio.load(instance().render('# :ok_hand:').html)
         const src = $('h1 > img[data-marp-twemoji]').attr('src')
 
         expect(src).toBe('https://twemoji.maxcdn.com/2/svg/1f44c.svg')
       })
+
+      describe('base option', () => {
+        it('uses specified base', () =>
+          expect(
+            instance({ base: '/assets/twemoji/' }).render(':+1:').html
+          ).toContain('/assets/twemoji/svg/1f44d.svg'))
+      })
+
+      describe('ext option', () => {
+        it('uses PNG emoji by setting png', () =>
+          expect(instance({ ext: 'png' }).render(':+1:').html).toContain(
+            'https://twemoji.maxcdn.com/2/72x72/1f44d.png'
+          ))
+      })
+    })
+
+    describe('twemojiBase option [soft-deprecated]', () => {
+      const instance = (emoji: EmojiOptions = {}) => new Marp({ emoji })
 
       it('uses specified base when twemojiBase option is defined', () => {
         const marp = instance({ twemojiBase: '/assets/twemoji/' })


### PR DESCRIPTION
Update Marp Core's emoji plugin to make twemoji image resources usable via PNG through `twemoji.ext` constructor option.

```javascript
const marp = new Marp({
  emoji: {
    twemoji: {
      ext: 'png'
    }
  }
})
```

This PR is a feedback from [@marp-team/marp-vscode](https://github.com/marp-team/marp-vscode) ([See code](https://github.com/marp-team/marp-vscode/blob/1d6d4ab5fc239347e7c89349b5c35b9347bcd9b7/src/extension.ts#L33-L45)). Several environments like VSCode cannot use external SVG images by security reason.

By this change, `emoji.twemojiBase` option will be soft-deprecated in favor of `emoji.twemoji.base`.