### PR TITLE
Fix over-sanitized attributes with HTML whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
 
 - Allow using twemoji via PNG by added `emoji.twemoji.ext` option ([#67](https://github.com/marp-team/marp-core/pull/67))
+- Support custom sanitizer for whitelisted HTML attributes ([#68](https://github.com/marp-team/marp-core/pull/68))
+
+### Fixed
+
+- Fix over-sanitized attributes with HTML whitelist ([#68](https://github.com/marp-team/marp-core/pull/68))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,16 @@ Setting whether to render raw HTML in Markdown.
 }
 ```
 
-Marp core allows only `<br>` tag by default, that is defined in [`Marp.html`](https://github.com/marp-team/marp-core/blob/3e854d0a50d4b1f36d01196169ab79ae171dbce1/src/marp.ts#L32-L34).
+```javascript
+// You may use custom attribute sanitizer by passing object.
+{
+  img: {
+    src: value => (value.startsWith('https://') ? value : '')
+  }
+}
+```
+
+Marp core allows only `<br>` tag by default, that is defined in [`Marp.html`](https://github.com/marp-team/marp-core/blob/d49064b5418053debd77485689f310bf1f7954d2/src/marp.ts#L39-L41).
 
 Whatever any option is selected, `<!-- HTML comment -->` is always parsed by Marpit for directives. When you are not disabled [Marpit's `inlineStyle` option](https://marpit-api.marp.app/marpit#Marpit) by `false`, `<style>` tags are parsed too for tweaking theme style.
 

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -13,7 +13,13 @@ import uncoverTheme from '../themes/uncover.scss'
 
 export interface MarpOptions extends MarpitOptions {
   emoji?: emojiPlugin.EmojiOptions
-  html?: boolean | { [tag: string]: string[] }
+  html?:
+    | boolean
+    | {
+        [tag: string]:
+          | string[]
+          | { [attr: string]: boolean | ((value: string) => string) }
+      }
   markdown?: object
   math?:
     | boolean

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -227,7 +227,7 @@ describe('Marp', () => {
     })
 
     context('with whitelist', () => {
-      const m = marp({ html: { hr: ['id'], p: ['class'] } })
+      const m = marp({ html: { img: ['src'], p: ['class'] } })
 
       it('allows whitelisted tags and attributes', () => {
         const md = '<p>\ntest\n</p>\n\n<p class="class" title="title">test</p>'
@@ -239,8 +239,10 @@ describe('Marp', () => {
       })
 
       it('renders void element with normalized', () => {
-        expect(m.render('<hr id="test">').html).toContain('<hr id="test" />')
-        expect(m.render('<hr class="test">').html).toContain('<hr />')
+        expect(m.render('<img src="a.png">').html).toContain(
+          '<img src="a.png" />'
+        )
+        expect(m.render('<img class="test">').html).toContain('<img />')
         expect(m.render('<p>').html).toContain('<p>')
       })
     })

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -264,6 +264,22 @@ describe('Marp', () => {
         expect(m.render('<img class="test">').html).toContain('<img />')
         expect(m.render('<p>').html).toContain('<p>')
       })
+
+      context('when attributes are defined as object', () => {
+        it('allows whitelisted attributes without defined false', () => {
+          const instance = marp({ html: { p: { id: true, class: false } } })
+          const { html } = instance.render('<p id="id" class="class"></p>')
+
+          expect(html).toContain('<p id="id"></p>')
+        })
+
+        it('applies custom sanitizer to attributes when function is defined', () => {
+          const instance = marp({ html: { p: { id: () => 'sanitized' } } })
+          const { html } = instance.render('<p id></p>')
+
+          expect(html).toContain('<p id="sanitized"></p>')
+        })
+      })
     })
 
     context("with markdown-it's xhtmlOut option as false", () => {


### PR DESCRIPTION
While processing #66, I've found over-sanitized attributes even if whitelisted. Let’s say running [Marp CLI](https://github.com/marp-team/marp-cli) with below option.

```json
{
  "options": {
    "html": {
      "img": ["src"]
    }
  }
}
```

By passing `<img src="marp.png">`, the content of `src` attribute would be vanished.

```bash
$ echo '<img src="marp.png">' | npx @marp-team/marp-cli -c ./marprc.json | grep "<img"
[  INFO ] Converting 1 markdown...
[  INFO ] <stdin> => <stdout>
<img src>
```

I guess it's came from `js-xss`'s default rule. I'll try to update [js-xss option](https://jsxss.com/en/options.html).
