### PR TITLE
Add usage of multiple classes in Gaia theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Allow using twemoji via PNG by added `emoji.twemoji.ext` option ([#67](https://github.com/marp-team/marp-core/pull/67))
 - Support custom sanitizer for whitelisted HTML attributes ([#68](https://github.com/marp-team/marp-core/pull/68))
+- Add usage of multiple classes in Gaia theme ([#69](https://github.com/marp-team/marp-core/pull/69))
 
 ### Fixed
 

--- a/themes/README.md
+++ b/themes/README.md
@@ -69,6 +69,25 @@ Gaia theme supports an additional color scheme by `gaia` class.
 <!-- class: gaia -->
 ```
 
+> :information_source: Of course you may use multiple classes, by array or separated string by space.
+>
+> ```markdown
+> ---
+> theme: gaia
+> class:
+>   - lead
+>   - invert
+> ---
+>
+> # Lead + invert
+>
+> ---
+>
+> <!-- class: lead gaia -->
+>
+> # Lead + gaia
+> ```
+
 ## Uncover
 
 [![](https://user-images.githubusercontent.com/3993388/48039495-5456b200-e1b8-11e8-8c82-ca7f7842b34d.png)][example]


### PR DESCRIPTION
Some users already have started creating theme for Marpit and Marp Core. (See [`marp` topic in community](https://github.com/topics/marp?q=topic%3Amarp+-org%3Amarp-team&unscoped_q=topic%3Amarp+-org%3Amarp-team))

However, I've also found a few themes that have an incorrect usage of `class`. This PR will show example that `class` directive can use for multiple classes. See also marp-team/marpit#51.

```markdown
---
theme: gaia
class:
  - lead
  - invert
---

# Lead + invert

---

<!-- class: lead gaia -->

# Lead + gaia
```

|`lead` + `invert`|`lead` + `gaia`|
|:---:|:---:|
|![](https://user-images.githubusercontent.com/3993388/52193314-fe1a0d80-2891-11e9-841c-27cdf97b66a8.png)|![](https://user-images.githubusercontent.com/3993388/52193322-05411b80-2892-11e9-8910-9ac688477804.png)|

