### PR TITLE
Upgrade Marpit to v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade Marpit to [v0.9.0](https://github.com/marp-team/marpit/releases/v0.9.0) ([#80](https://github.com/marp-team/marp-core/pull/80))
+
+### Removed
+
+- Deprecated `twemojiBase` option ([#80](https://github.com/marp-team/marp-core/pull/80))
+
 ## v0.7.1 - 2019-03-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@marp-team/marpit": "^0.8.0",
+    "@marp-team/marpit": "^0.9.0",
     "@marp-team/marpit-svg-polyfill": "^0.3.0",
     "emoji-regex": "^8.0.0",
     "highlight.js": "^9.15.6",

--- a/src/html/html.ts
+++ b/src/html/html.ts
@@ -2,7 +2,6 @@ import selfClosingTags from 'self-closing-tags'
 import { FilterXSS } from 'xss'
 import { friendlyAttrValue, escapeAttrValue } from 'xss/lib/default'
 import { MarpOptions } from '../marp'
-import { marpEnabledSymbol } from '../symbol'
 
 const selfClosingRegexp = /\s*\/?>$/
 const xhtmlOutFilter = new FilterXSS({
@@ -21,8 +20,6 @@ export function markdown(md): void {
 
   const sanitizedRenderer = (original: Function) => (...args) => {
     const ret = original(...args)
-    if (!md[marpEnabledSymbol]) return ret
-
     const whiteList = {}
     const html: MarpOptions['html'] = md.options.html
 

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -35,16 +35,16 @@ export const markdown = marpitPlugin(
     }
 
     md.core.ruler.before('block', 'marp_math_initialize', state => {
-      if (!state.inlineMode) {
-        updateState(false)
+      if (state.inlineMode) return
 
-        if (md.marpit.options.math) {
-          md.block.ruler.enable('marp_math_block')
-          md.inline.ruler.enable('marp_math_inline')
-        } else {
-          md.block.ruler.disable('marp_math_block')
-          md.inline.ruler.disable('marp_math_inline')
-        }
+      updateState(false)
+
+      if (md.marpit.options.math) {
+        md.block.ruler.enable('marp_math_block')
+        md.inline.ruler.enable('marp_math_inline')
+      } else {
+        md.block.ruler.disable('marp_math_block')
+        md.inline.ruler.disable('marp_math_inline')
       }
     })
 
@@ -79,9 +79,7 @@ export const markdown = marpitPlugin(
         }
         return false
       },
-      {
-        alt: ['paragraph', 'reference', 'blockquote', 'list'],
-      }
+      { alt: ['paragraph', 'reference', 'blockquote', 'list'] }
     )
 
     md.renderer.rules.marp_math_block = (tokens, idx) => {

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -1,1 +1,0 @@
-export const marpEnabledSymbol = Symbol('marpEnabled')

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -3,6 +3,13 @@ declare module '*.scss' {
   export default scss
 }
 
+declare module '@marp-team/marpit/lib/markdown/marpit_plugin' {
+  const marpitPlugin: <F extends (md: any, ...args: any[]) => void>(
+    func: F
+  ) => F
+  export default marpitPlugin
+}
+
 declare module 'katex/package.json' {
   export const version: string
 }

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -6,10 +6,6 @@ import context from './_helpers/context'
 import { EmojiOptions } from '../src/emoji/emoji'
 import browser from '../src/browser'
 import { Marp, MarpOptions } from '../src/marp'
-import { marpEnabledSymbol } from '../src/symbol'
-
-const marpitDisablePlugin = md =>
-  md.core.ruler.before('normalize', 'disable', sc => sc.marpit(false))
 
 jest.mock('../src/browser')
 jest.mock('../src/math/katex.scss')
@@ -159,36 +155,6 @@ describe('Marp', () => {
           ))
       })
     })
-
-    describe('twemojiBase option [deprecated]', () => {
-      const instance = (emoji: EmojiOptions = {}) => new Marp({ emoji })
-
-      it('uses specified base when twemojiBase option is defined', () => {
-        const warn = jest.spyOn(console, 'warn')
-        const marp = instance({ twemojiBase: '/assets/twemoji/' })
-        const $ = cheerio.load(marp.render('# :ok_hand:').html)
-        const src = $('h1 > img[data-marp-twemoji]').attr('src')
-
-        expect(src).toBe('/assets/twemoji/svg/1f44c.svg')
-        expect(warn).toBeCalledWith(
-          expect.stringContaining('Deprecation warning')
-        )
-      })
-    })
-
-    context('with disabled Marpit features', () => {
-      const instance = marp().use(marpitDisablePlugin)
-
-      it('does not convert emoji shorthand to twemoji image', () => {
-        const { html } = instance.render('# :heart:')
-        expect(cheerio.load(html)('img[data-marp-twemoji]')).toHaveLength(0)
-      })
-
-      it('does not convert unicode emoji to twemoji image', () => {
-        const { html } = instance.render('👍 `👍`\n\n```\n👍\n```\n\n\t👍')
-        expect(cheerio.load(html)('img[data-marp-twemoji]')).toHaveLength(0)
-      })
-    })
   })
 
   describe('html option', () => {
@@ -304,20 +270,6 @@ describe('Marp', () => {
         expect(m.render('<br />').html).toContain('<br />')
         expect(m.render('<br class="sanitize">').html).toContain('<br>')
         expect(m.render('<br></br>').html).toContain('<br></br>')
-      })
-    })
-
-    context('with disabled Marpit features', () => {
-      const instance = marp().use(marpitDisablePlugin)
-
-      it('does not sanitize HTML', () => {
-        const { html } = instance.render(
-          '<b data-custom="test">abc</b>\n\n<div>\ntest\n</div>'
-        )
-        const $ = cheerio.load(html)
-
-        expect($('b[data-custom="test"]')).toHaveLength(1)
-        expect($('div')).toHaveLength(1)
       })
     })
   })
@@ -458,17 +410,6 @@ describe('Marp', () => {
         expect(css).not.toContain('.katex')
       })
     })
-
-    context('with disabled Marpit features', () => {
-      const instance = marp().use(marpitDisablePlugin)
-
-      it('does not render KaTeX', () => {
-        const { html } = instance.render(`${inline}\n\n${block}`)
-        const $ = cheerio.load(html)
-
-        expect($('.katex')).toHaveLength(0)
-      })
-    })
   })
 
   describe('Element fitting', () => {
@@ -521,15 +462,6 @@ describe('Marp', () => {
             expect($('h1').text()).toContain('fitting')
           })
         }
-
-        context('with disabled Marpit features', () => {
-          const instance = marp().use(marpitDisablePlugin)
-
-          it('does not wrap by SVG', () => {
-            const { html } = instance.render(baseMd)
-            expect(cheerio.load(html)('svg')).toHaveLength(0)
-          })
-        })
       }
     )
 
@@ -570,15 +502,6 @@ describe('Marp', () => {
 
         expect($('section svg')).toHaveLength(0)
       })
-
-      context('with disabled Marpit features', () => {
-        const instance = marp().use(marpitDisablePlugin)
-
-        it('does not wrap by SVG', () => {
-          const { html } = instance.render(markdown)
-          expect(cheerio.load(html)('svg')).toHaveLength(0)
-        })
-      })
     })
 
     context('with fence (Auto scaling for fence)', () => {
@@ -614,15 +537,6 @@ describe('Marp', () => {
         expect(plainContent).toHaveLength(1)
         expect($('pre').text()).toContain('const a = 1')
       })
-
-      context('with disabled Marpit features', () => {
-        const instance = marp().use(marpitDisablePlugin)
-
-        it('does not wrap by SVG', () => {
-          const { html } = instance.render(markdown)
-          expect(cheerio.load(html)('svg')).toHaveLength(0)
-        })
-      })
     })
 
     context('with math block', () => {
@@ -648,15 +562,6 @@ describe('Marp', () => {
         const plainContent = $('p > span[data-marp-fitting="plain"] .katex')
 
         expect(plainContent.length).toBeTruthy()
-      })
-
-      context('with disabled Marpit features', () => {
-        const instance = marp().use(marpitDisablePlugin)
-
-        it('does not wrap by SVG', () => {
-          const { html } = instance.render(markdown)
-          expect(cheerio.load(html)('svg')).toHaveLength(0)
-        })
       })
     })
   })
@@ -728,18 +633,6 @@ describe('Marp', () => {
       const markdownIt = new MarkdownIt().use(marp().markdownItPlugins)
 
       expect(markdownIt.render('')).toContain('section')
-      expect(markdownIt[marpEnabledSymbol]).toBe(true)
-    })
-
-    context('with disabled Marpit features by StateCore#marpit', () => {
-      const markdownIt = new MarkdownIt()
-        .use(marp().markdownItPlugins)
-        .use(marpitDisablePlugin)
-
-      it('returns converted result of plain Markdown', () => {
-        expect(markdownIt.render('')).not.toContain('section')
-        expect(markdownIt[marpEnabledSymbol]).toBe(false)
-      })
     })
   })
 

--- a/test/math/math.ts
+++ b/test/math/math.ts
@@ -11,7 +11,10 @@ const countMath = stt => stt.split('class="katex"').length - 1
 const countBlockMath = stt => stt.split('class="katex-display"').length - 1
 
 describe('markdown-it math plugin', () => {
-  const md = new MarkdownIt().use(mathPlugin)
+  const md = new MarkdownIt()
+
+  md.marpit = { options: { math: true } }
+  md.use(mathPlugin)
 
   it('renders simple inline math', () => {
     const rendered = md.render('$1+1 = 2$')

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,13 +302,13 @@
   dependencies:
     detect-browser "^4.1.0"
 
-"@marp-team/marpit@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.8.0.tgz#f53ea265290c5f6d245eb04da5d425013306207f"
-  integrity sha512-ge2KTKHYkOhtLXRoy9R0dq1jJ9MrmCjVtnYmqhniLNNakVW/32+hXOK6FdgZqNQAe2m9smfTsXT2eBKUgLsxyg==
+"@marp-team/marpit@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-0.9.0.tgz#5a12f00a97832907806af81933d8d2f5e25cb4e6"
+  integrity sha512-nPtIXu2leY/EDKsjvu3g4tsa98yRAXpM1w2bpUUKLtPC0wirdhxIJWGjW8W24Hm0+c+F/f3jibE7B15fTCVweA==
   dependencies:
     color-string "^1.5.3"
-    js-yaml "^3.12.2"
+    js-yaml "^3.13.0"
     lodash.kebabcase "^4.1.1"
     markdown-it "^8.4.2"
     markdown-it-front-matter "^0.1.2"
@@ -3390,10 +3390,10 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.12.0, js-yaml@^3.12.2, js-yaml@^3.7.0, js-yaml@^3.9.0:
-  version "3.12.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.2.tgz#ef1d067c5a9d9cb65bd72f285b5d8105c77f14fc"
-  integrity sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==
+js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.7.0, js-yaml@^3.9.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
+  integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
This PR will upgrade Marpit to [v0.9.0](https://github.com/marp-team/marpit/releases/v0.9.0) via `yarn upgrade-interactive --latest`. This release has a lot of changes that would break Marp Core internals, so we are working in separated PR.

- The enhanced plugin system is rejected. We have removed logics for detection Marpit enable state.
- Marp (Marpit) instance is injected to markdown-it instance and Marpit internal plugins requires it. Now, we are following a way of Marpit plugin.

An architecture of Marp plugin becomes to be simple.

> In addition to this change, a deprecated `twemojiBase` option is removed.