### PR TITLE
Update pagination style in uncover theme to use inline SVG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@
 
 ### Added
 
-- Text color shorthand via image syntax, from Marpit v1 ([#87](https://github.com/marp-team/marp-core/pull/87))
+- Shorthand for text color by image syntax, from Marpit v1 ([#87](https://github.com/marp-team/marp-core/pull/87))
 - Test with Node 12 (Erbium) ([#87](https://github.com/marp-team/marp-core/pull/87))
 - Automate GitHub release ([#87](https://github.com/marp-team/marp-core/pull/87))
+
+### Fixed
+
+- Improve rendering compatibility of uncover theme's pagination in PDF.js ([#84](https://github.com/marp-team/marp-core/pull/84), [#86](https://github.com/marp-team/marp-core/pull/87))
 
 ### Changed
 

--- a/themes/uncover.scss
+++ b/themes/uncover.scss
@@ -20,7 +20,6 @@
     background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 1 1" width="1" height="1"><path d="M0 1h1v-1Z" fill="#{rgba($text, 0.05)}"/></svg>')
       no-repeat center center;
     background-size: cover;
-
     color: $text;
     text-shadow: 0 0 5px $bg;
   }

--- a/themes/uncover.scss
+++ b/themes/uncover.scss
@@ -12,7 +12,15 @@
   color: $text;
 
   &::after {
-    background: linear-gradient(-45deg, rgba($text, 0.05) 50%, transparent 50%);
+    /*
+     * Gradient with hard stops has incorrect rendering in Firefox's PDF.js
+     * @see https://github.com/mozilla/pdf.js/issues/10572
+     */
+    // background: linear-gradient(-45deg, rgba($text, 0.05) 50%, transparent 50%);
+    background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 1 1" width="1" height="1"><path d="M0 1h1v-1Z" fill="#{rgba($text, 0.05)}"/></svg>')
+      no-repeat center center;
+    background-size: cover;
+
     color: $text;
     text-shadow: 0 0 5px $bg;
   }


### PR DESCRIPTION
Fix rendering compatibility in the exported PDF opened by PDF.js. Resolves #84. (but blocked by ~~#85~~ #87)