### PR TITLE
Remove unnecessary dependency of markdown-it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - Upgrade Marpit to v1 ([#87](https://github.com/marp-team/marp-core/pull/87))
 - Swap Sass compiler from node-sass to Dart Sass ([#87](https://github.com/marp-team/marp-core/pull/87))
 
+### Removed
+
+- Remove unnecessary dependency of markdown-it ([#88](https://github.com/marp-team/marp-core/pull/88))
+
 ## v0.8.0 - 2019-04-08
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "github-markdown-css": "^3.0.1",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",
+    "markdown-it": "^8.4.2",
     "node-sass-package-importer": "^5.3.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^7.0.14",
@@ -95,7 +96,6 @@
     "emoji-regex": "^8.0.0",
     "highlight.js": "^9.15.6",
     "katex": "^0.10.1",
-    "markdown-it": "^8.4.2",
     "markdown-it-emoji": "^1.4.0",
     "twemoji": "^12.0.0",
     "xss": "^1.0.6"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ const plugins = [
 
 export default [
   {
-    external: [...Object.keys(pkg.dependencies), 'markdown-it/lib/token'],
+    external: Object.keys(pkg.dependencies),
     input: `src/${path.basename(pkg.main, '.js')}.ts`,
     output: { exports: 'named', file: pkg.main, format: 'cjs' },
     plugins,


### PR DESCRIPTION
Move dependency of markdown-it to `devDependencies`. markdown-it includes in Marpit module, and it does no longer use directly in Marp Core.