### PR TITLE
Add 4:3 Themes

### DIFF
--- a/src/marp.ts
+++ b/src/marp.ts
@@ -9,6 +9,9 @@ import * as mathPlugin from './math/math'
 import defaultTheme from '../themes/default.scss'
 import gaiaTheme from '../themes/gaia.scss'
 import uncoverTheme from '../themes/uncover.scss'
+import default43Theme from '../themes/default43.scss'
+import gaia43Theme from '../themes/gaia43.scss'
+import uncover43Theme from '../themes/uncover43.scss'
 
 export interface MarpOptions extends MarpitOptions {
   emoji?: emojiPlugin.EmojiOptions
@@ -66,6 +69,9 @@ export class Marp extends Marpit {
     this.themeSet.default = this.themeSet.add(defaultTheme)
     this.themeSet.add(gaiaTheme)
     this.themeSet.add(uncoverTheme)
+    this.themeSet.add(default43Theme)
+    this.themeSet.add(gaia43Theme)
+    this.themeSet.add(uncover43Theme)
   }
 
   protected applyMarkdownItPlugins(md) {

--- a/themes/default43.scss
+++ b/themes/default43.scss
@@ -1,0 +1,10 @@
+/*!
+ * @theme default43
+ */
+
+@import 'default';
+
+section {
+  width: 960px;
+  height: 720px;
+}

--- a/themes/gaia43.scss
+++ b/themes/gaia43.scss
@@ -1,0 +1,10 @@
+/*!
+ * @theme gaia43
+ */
+
+@import 'gaia';
+
+section {
+  width: 960px;
+  height: 720px;
+}

--- a/themes/uncover43.scss
+++ b/themes/uncover43.scss
@@ -1,0 +1,10 @@
+/*!
+ * @theme uncover43
+ */
+
+@import 'uncover';
+
+section {
+  width: 960px;
+  height: 720px;
+}


### PR DESCRIPTION
Since the Marp needs a theme to produce 4:3 slide, it had better include the themes inside for convenience.

Sorry, I just wrote this patch, not tested.