### PR TITLE
Optimize default theme CSS on build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add `minifyCSS` option ([#103](https://github.com/marp-team/marp-core/pull/103))
 - Add `dollarPrefixForGlobalDirectives` option _(not for users)_ ([#104](https://github.com/marp-team/marp-core/pull/104))
 
+### Fixed
+
+- Optimize default theme CSS by removing `.markdown-body` selector on build time ([#106](https://github.com/marp-team/marp-core/pull/106))
+
 ### Changed
 
 - Update CircleCI configuration to use v2.1 ([#101](https://github.com/marp-team/marp-core/pull/101))

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ import postcss from 'rollup-plugin-postcss'
 import { terser } from 'rollup-plugin-terser'
 import typescript from 'rollup-plugin-typescript'
 import pkg from './package.json'
+import postcssOptimizeDefaultTheme from './scripts/postcss-optimize-default-theme'
 
 const plugins = [
   json({ preferConst: true }),
@@ -28,6 +29,7 @@ const plugins = [
       ],
     },
     plugins: [
+      postcssOptimizeDefaultTheme(),
       postcssUrl({
         filter: '**/assets/**/*.svg',
         encodeType: 'base64',

--- a/scripts/postcss-optimize-default-theme.js
+++ b/scripts/postcss-optimize-default-theme.js
@@ -1,0 +1,20 @@
+import postcss from 'postcss'
+
+const defaultThemeMatcher = /@theme +default/
+
+const plugin = postcss.plugin('postcss-optimize-default-theme', () => css => {
+  if (!defaultThemeMatcher.test(css.source.input.css)) return
+
+  // Remove rules for .markdown-body selector
+  css.walkRules(rule => {
+    const ss = rule.selectors.filter(s => !s.startsWith('.markdown-body'))
+
+    if (ss.length > 0) {
+      rule.selectors = ss
+    } else {
+      rule.remove()
+    }
+  })
+})
+
+export default plugin


### PR DESCRIPTION
Apply optimization for default theme CSS on build time.

Marp core's default theme is based on GitHub style so we have bundled declarations not only for `section` tag (Marpit slide container) but also `.markdown-body` class. Commonly they are useless in Marp and just would output huge CSS.

Therefore I created postcss plugin for rollup bundle to remove selectors started with `.markdown-body`.