### PR TITLE
Fix dollar prefix option to support size directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix dollar prefix option to support `size` directive ([#107](https://github.com/marp-team/marp-core/pull/107))
+
 ## v0.13.0 - 2019-09-12
 
 ### Added

--- a/src/dollar/dollar.ts
+++ b/src/dollar/dollar.ts
@@ -5,7 +5,16 @@ import { Marp } from '../marp'
 export const markdown = marpitPlugin(({ marpit: marp }: { marpit: Marp }) => {
   if (!marp.options.dollarPrefixForGlobalDirectives) return
 
+  const customGlobalDirectives = Object.keys(marp.customDirectives.global)
+
+  // Marpit built-in directives
   marp.customDirectives.global.$theme = v => ({ theme: v })
   marp.customDirectives.global.$style = v => ({ style: v })
   marp.customDirectives.global.$headingDivider = v => ({ headingDivider: v })
+
+  // Custom global directives (e.g. `$size`)
+  for (const d of customGlobalDirectives) {
+    marp.customDirectives.global[`$${d}`] = v =>
+      marp.customDirectives.global[d](v)
+  }
 })

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -616,6 +616,12 @@ describe('Marp', () => {
           htmlAsArray: true,
         }).html
       ).toHaveLength(1)
+
+      // $size (Custom directives extended by Marp Core)
+      const [html] = instance.render('<!-- $size: 4:3 -->', {
+        htmlAsArray: true,
+      }).html
+      expect(html).not.toContain('0 0 960 720')
     })
 
     context('with true', () => {
@@ -638,6 +644,11 @@ describe('Marp', () => {
             htmlAsArray: true,
           }).html
         ).toHaveLength(2)
+
+        const [html] = instance.render('<!-- $size: 4:3 -->', {
+          htmlAsArray: true,
+        }).html
+        expect(html).toContain('0 0 960 720')
       })
     })
   })


### PR DESCRIPTION
#104 lacked supporting `$size` global directive, added by Marp Core.