### PR TITLE
Stop overriding markdown-it's html option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Upgrade Marpit to [v1.4.1](https://github.com/marp-team/marpit/releases/v1.4.1) ([#113](https://github.com/marp-team/marp-core/pull/113))
 - Upgrade dependent packages to the latest version ([#109](https://github.com/marp-team/marp-core/pull/109), [#113](https://github.com/marp-team/marp-core/pull/113))
 - Apply `font-display: swap` to Google Fonts in Gaia theme ([#114](https://github.com/marp-team/marp-core/pull/114))
+- Reduce inconsistency about `html` option between Marp Core and markdown-it option ([#111](https://github.com/marp-team/marp-core/pull/111), [#117](https://github.com/marp-team/marp-core/pull/117))
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -203,11 +203,12 @@ const marp = new Marp({
 
 ### `html`: _`boolean`_ | _`object`_
 
-Setting whether to render raw HTML in Markdown.
+Setting whether to render raw HTML in Markdown. It's an alias to `markdown.html` ([markdown-it option](https://markdown-it.github.io/markdown-it/#MarkdownIt.new)) but has additional feature about HTML whitelist.
 
 - `true`: The all HTML will be allowed.
 - `false`: All HTML except supported in Marpit Markdown will be disallowed.
-- By passing `object`, you can set the whitelist to specify allowed tags and attributes.
+
+By passing `object`, you can set the whitelist to specify allowed tags and attributes.
 
 ```javascript
 // Specify tag name as key, and attributes to allow as string array.
@@ -229,8 +230,6 @@ Setting whether to render raw HTML in Markdown.
 Marp core allows only `<br>` tag by default, that is defined in [`Marp.html`](https://github.com/marp-team/marp-core/blob/d49064b5418053debd77485689f310bf1f7954d2/src/marp.ts#L39-L41).
 
 Whatever any option is selected, `<!-- HTML comment -->` is always parsed by Marpit for directives. When you are not disabled [Marpit's `inlineStyle` option](https://marpit-api.marp.app/marpit#Marpit) by `false`, `<style>` tags are parsed too for tweaking theme style.
-
-> :information_source: `html` flag in `markdown` option cannot use because of overridden by this.
 
 ### `emoji`: _`object`_
 

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -46,9 +46,7 @@ export class Marp extends Marpit {
 
   private renderedMath: boolean = false
 
-  static html: MarpOptions['html'] = {
-    br: [],
-  }
+  static readonly html = { br: [] }
 
   constructor(opts: MarpOptions = {}) {
     super({
@@ -57,7 +55,6 @@ export class Marp extends Marpit {
       math: true,
       minifyCSS: true,
       script: true,
-      html: Marp.html,
       dollarPrefixForGlobalDirectives: false,
       ...opts,
       emoji: {
@@ -70,10 +67,9 @@ export class Marp extends Marpit {
         {
           breaks: true,
           linkify: true,
-          highlight: (code: string, lang: string) =>
-            this.highlighter(code, lang),
-          ...(typeof opts.markdown === 'object' ? opts.markdown : {}),
+          highlight: (code, lang) => this.highlighter(code, lang),
           html: opts.html !== undefined ? opts.html : Marp.html,
+          ...(typeof opts.markdown === 'object' ? opts.markdown : {}),
         },
       ],
     } as MarpOptions)

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -192,14 +192,6 @@ describe('Marp', () => {
         expect($('header > strong')).toHaveLength(1)
         expect($('footer > em')).toHaveLength(1)
       })
-
-      it('allows overriding html option through markdown-it instance', () => {
-        const instance = marp()
-        instance.markdown.set({ html: { b: [] } })
-
-        const { html } = instance.render('<b>abc</b>')
-        expect(cheerio.load(html)('b')).toHaveLength(1)
-      })
     })
 
     context('with true', () => {
@@ -231,11 +223,19 @@ describe('Marp', () => {
     })
 
     context('with whitelist', () => {
-      const m = marp({ html: { img: ['src'], p: ['class'] } })
+      const md = '<p>\ntest\n</p>\n\n<p class="class" title="title">test</p>'
+      const html = { img: ['src'], p: ['class'] }
 
       it('allows whitelisted tags and attributes', () => {
-        const md = '<p>\ntest\n</p>\n\n<p class="class" title="title">test</p>'
-        const $ = cheerio.load(m.render(md).html)
+        const $ = cheerio.load(marp({ html }).render(md).html)
+
+        expect($('p')).toHaveLength(2)
+        expect($('p.class')).toHaveLength(1)
+        expect($('p[title]')).toHaveLength(0)
+      })
+
+      it('allows using html option passed to markdown-it option', () => {
+        const $ = cheerio.load(marp({ markdown: { html } }).render(md).html)
 
         expect($('p')).toHaveLength(2)
         expect($('p.class')).toHaveLength(1)
@@ -243,6 +243,8 @@ describe('Marp', () => {
       })
 
       it('renders void element with normalized', () => {
+        const m = marp({ html })
+
         expect(m.render('<img src="a.png">').html).toContain(
           '<img src="a.png" />'
         )
@@ -276,6 +278,14 @@ describe('Marp', () => {
         expect(m.render('<br class="sanitize">').html).toContain('<br>')
         expect(m.render('<br></br>').html).toContain('<br></br>')
       })
+    })
+
+    it('allows overriding html option through markdown-it instance', () => {
+      const instance = marp()
+      instance.markdown.set({ html: { b: [] } })
+
+      const { html } = instance.render('<b>abc</b>')
+      expect(cheerio.load(html)('b')).toHaveLength(1)
     })
   })
 


### PR DESCRIPTION
#74 makes `html` constructor option for Marp Core just an alias into [markdown-it's `html` option](https://markdown-it.github.io/markdown-it/#MarkdownIt.new) that has expected boolean. We are passing the whitelist object to `html` for a while, and had recieved no troubles about compatibility with markdown-it plugins.

Resolves #111.