### PR TITLE
Define word-wrap css property as break-word in gaia and uncover theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 - Upgrade Marpit to [v1.4.1](https://github.com/marp-team/marpit/releases/v1.4.1) ([#113](https://github.com/marp-team/marp-core/pull/113))
 - Upgrade dependent packages to the latest version ([#109](https://github.com/marp-team/marp-core/pull/109), [#113](https://github.com/marp-team/marp-core/pull/113))
-- Apply `font-display: swap` to Google Fonts in Gaia theme ([#114](https://github.com/marp-team/marp-core/pull/114))
+- Apply `font-display: swap` to Google Fonts in gaia theme ([#114](https://github.com/marp-team/marp-core/pull/114))
+- Define `word-wrap` css property as `break-word` in gaia and uncover theme ([#108](https://github.com/marp-team/marp-core/pull/108), [#119](https://github.com/marp-team/marp-core/pull/119))
 - Reduce inconsistency about `html` option between Marp Core and markdown-it option ([#111](https://github.com/marp-team/marp-core/pull/111), [#117](https://github.com/marp-team/marp-core/pull/117))
 
 ### Deprecated

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -222,6 +222,7 @@ section {
   letter-spacing: 1.25px;
   padding: 70px;
   width: 1280px;
+  word-wrap: break-word;
 
   > *:first-child,
   > header:first-child + * {

--- a/themes/uncover.scss
+++ b/themes/uncover.scss
@@ -77,6 +77,7 @@ section {
   position: relative;
   text-align: center;
   width: 1280px;
+  word-wrap: break-word;
   z-index: 0;
 
   &::after {


### PR DESCRIPTION
Resolves #108. It is based on feedback to https://github.com/marp-team/marp-vscode/issues/76.

I expected a contribution from community but there was nothing for a month, so I've added by myself.