### PR TITLE
Fix type definition for browser to export default func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix type definition for browser to export default func ([#120](https://github.com/marp-team/marp-core/pull/120))
+
 ## v0.14.0 - 2019-10-19
 
 ### Added

--- a/browser.d.ts
+++ b/browser.d.ts
@@ -1,1 +1,2 @@
 export * from './types/src/browser'
+export { default } from './types/src/browser'


### PR DESCRIPTION
`export * from 'xxx'` has not exported default function.