### PR TITLE
Add strikethrough to default features

### DIFF
--- a/src/marp.ts
+++ b/src/marp.ts
@@ -74,7 +74,7 @@ export class Marp extends Marpit {
       ],
     } as MarpOptions)
 
-    this.markdown.enable(['table', 'linkify'])
+    this.markdown.enable(['table', 'linkify', 'strikethrough'])
 
     // Theme support
     this.themeSet.metaType = Object.freeze({

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -39,6 +39,11 @@ describe('Marp', () => {
       const $ = cheerio.load(marp().markdown.render(address))
       expect($(`a[href="${address}"]`).text()).toBe(address)
     })
+
+    it('has enabled strikethrough syntax', () => {
+      const $ = cheerio.load(marp().markdown.render('~~strikethrough~~'))
+      expect($('s')).toHaveLength(1)
+    })
   })
 
   describe('emoji option', () => {


### PR DESCRIPTION
Resolves #102 

Add strikethrough (`~~abc~~` to ~~abc~~) to default features with [markdown-it](https://github.com/markdown-it/markdown-it/blob/486585270006c4b817bf9fa770fdfb1a60cd54c1/lib/parser_inline.js#L20).