### PR TITLE
Expose selected size as data-size attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Breaking
 
-- Marp Core requires Node >= 10 ([#135](https://github.com/marp-team/marp-core/issues/135), [#143](https://github.com/marp-team/marp-core/pull/143))
+- Marp Core requires Node >= 10 ([#143](https://github.com/marp-team/marp-core/pull/143))
 
 ### Added
 
-- Expose selected size as `data-size` attribute ([#143](https://github.com/marp-team/marp-core/pull/144))
+- Expose selected size as `data-size` attribute ([#135](https://github.com/marp-team/marp-core/issues/135), [#144](https://github.com/marp-team/marp-core/pull/144))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Breaking
 
-- Marp Core requires Node >= 10 ([#143](https://github.com/marp-team/marp-core/pull/143))
+- Marp Core requires Node >= 10 ([#135](https://github.com/marp-team/marp-core/issues/135), [#143](https://github.com/marp-team/marp-core/pull/143))
+
+### Added
+
+- Expose selected size as `data-size` attribute ([#143](https://github.com/marp-team/marp-core/pull/144))
 
 ### Changed
 

--- a/src/size/size.ts
+++ b/src/size/size.ts
@@ -12,6 +12,8 @@ interface RestorableThemes {
   themes: Set<Theme>
 }
 
+const sizePluginSymbol = Symbol('marp-size-plugin')
+
 export const markdown = marpitPlugin(md => {
   const marp: Marp = md.marpit
   const { render } = marp
@@ -38,9 +40,10 @@ export const markdown = marpitPlugin(md => {
     default: undefined,
   }
 
-  // `size` global directive
-  marp.customDirectives.global.size = size =>
-    typeof size === 'string' ? { size } : {}
+  // Define `size` global directive
+  Object.defineProperty(marp.customDirectives.global, 'size', {
+    value: size => (typeof size === 'string' ? { size } : {}),
+  })
 
   // Override render method to restore original theme set
   marp.render = (...args) => {
@@ -66,6 +69,8 @@ export const markdown = marpitPlugin(md => {
     const customSize = definedSizes(themeInstance).get(size)
 
     if (customSize) {
+      state[sizePluginSymbol] = size
+
       const { width, height } = customSize
       const css = `${themeInstance.css}\nsection{width:${width};height:${height};}`
 
@@ -85,6 +90,15 @@ export const markdown = marpitPlugin(md => {
       if (marp.themeSet.has(overrideTheme.name)) {
         marp.themeSet.addTheme(overrideTheme)
       }
+    }
+  })
+
+  md.core.ruler.after('marpit_directives_apply', 'marp_size_apply', state => {
+    if (state.inlineMode || !state[sizePluginSymbol]) return
+
+    for (const token of state.tokens) {
+      const { marpitDirectives } = token.meta || {}
+      if (marpitDirectives) token.attrSet('data-size', state[sizePluginSymbol])
     }
   })
 })

--- a/src/size/size.ts
+++ b/src/size/size.ts
@@ -101,4 +101,18 @@ export const markdown = marpitPlugin(md => {
       if (marpitDirectives) token.attrSet('data-size', state[sizePluginSymbol])
     }
   })
+
+  md.core.ruler.after(
+    'marpit_advanced_background',
+    'marp_size_apply_advanced_background',
+    state => {
+      if (state.inlineMode || !state[sizePluginSymbol]) return
+
+      for (const token of state.tokens) {
+        if (token.type === 'marpit_advanced_pseudo_section_open') {
+          token.attrSet('data-size', state[sizePluginSymbol])
+        }
+      }
+    }
+  )
 })

--- a/test/size/size.ts
+++ b/test/size/size.ts
@@ -1,4 +1,5 @@
 import { Marpit, Theme } from '@marp-team/marpit'
+import cheerio from 'cheerio'
 import postcss from 'postcss'
 import { markdown as sizePlugin } from '../../src/size/size'
 
@@ -72,9 +73,25 @@ describe('Size plugin', () => {
       expect(instance.themeSet.getThemeProp('a', 'height')).toBe(baseHeight)
     })
 
+    it('exposes selected size into <section> element as data-size attribute', () => {
+      const { html } = instance.render('<!--\ntheme: a\nsize: test\n-->\n\n---')
+      const $ = cheerio.load(html)
+
+      $('section')
+        .map((_, e) => $(e).data('size'))
+        .each((_, attr) => expect(attr).toBe('test'))
+    })
+
     it('ignores undefined size name', () => {
       const { css } = instance.render('<!-- theme: a -->\n<!-- size: dummy -->')
       expect(css).toBe(instance.render('<!-- theme: a -->').css)
+    })
+
+    it('does not expose undefined size as data-size attribute', () => {
+      const { html } = instance.render('<!--\ntheme: a\nsize: dummy\n-->')
+      const $ = cheerio.load(html)
+
+      expect($('section').data('size')).toBeUndefined()
     })
 
     it('ignores invalid size directive', () => {


### PR DESCRIPTION
Marp Core size plugin has implemented exposing selected size into `<section>` elements as `data-size` attribute. The author of theme for Marp Core can define style per size.

Resolves #135 and #134.