### PR TITLE
Remove deprecated Marp.ready()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Removed
 
 - EOL Node 8 is no longer supported ([#143](https://github.com/marp-team/marp-core/pull/143))
+- Remove deprecated `Marp.ready()` (Use `@marp-team/marp-core/browser` entrypoint) ([#145](https://github.com/marp-team/marp-core/pull/145))
 
 ## v0.15.2 - 2019-11-18
 

--- a/src/marp.ts
+++ b/src/marp.ts
@@ -5,7 +5,6 @@ import postcssMinifyParams from 'postcss-minify-params'
 import postcssMinifySelectors from 'postcss-minify-selectors'
 import postcssNormalizeWhitespace from 'postcss-normalize-whitespace'
 import { version } from 'katex/package.json'
-import browser from './browser'
 import * as emojiPlugin from './emoji/emoji'
 import * as fittingPlugin from './fitting/fitting'
 import * as htmlPlugin from './html/html'
@@ -130,14 +129,6 @@ export class Marp extends Marpit {
     }
 
     return base
-  }
-
-  /** @deprecated A script for the browser that is equivalent to `Marp.ready()` has injected into rendered Markdown by default. `Marp.ready()` will remove in future so you have to use `@marp-team/marp-core/browser` instead if you want to execute browser script in script-disabled HTML manually via using such as webpack. */
-  static ready() {
-    console.warn(
-      '[DEPRECATION WARNING] A script for the browser that is equivalent to Marp.ready() has injected into rendered Markdown by default. Marp.ready() will remove in future so you have to use "@marp-team/marp-core/browser" instead if you want to execute browser script in script-disabled HTML manually via using such as webpack.'
-    )
-    browser()
   }
 }
 

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -3,7 +3,6 @@ import cheerio from 'cheerio'
 import postcss from 'postcss'
 import { EmojiOptions } from '../src/emoji/emoji'
 import { Marp, MarpOptions } from '../src/marp'
-import observer from '../src/observer'
 import browserScript from '../src/script/browser-script'
 
 jest.mock('../src/observer')
@@ -751,27 +750,6 @@ describe('Marp', () => {
 
       it('highlights with custom highlighter', () =>
         expect($('code .customized')).toHaveLength(1))
-    })
-  })
-
-  describe('.ready', () => {
-    it('throws error in node environment', () =>
-      expect(() => Marp.ready()).toThrowError())
-
-    context('when window object is defined in global', () => {
-      beforeEach(() => {
-        global['window'] = jest.fn()
-        jest.spyOn(console, 'warn').mockImplementation()
-      })
-      afterEach(() => delete global['window'])
-
-      it('registers observer for browser only once', () => {
-        Marp.ready()
-        expect(observer).toHaveBeenCalledTimes(1)
-
-        Marp.ready()
-        expect(observer).toHaveBeenCalledTimes(1)
-      })
     })
   })
 })


### PR DESCRIPTION
Removed deprecated `Marp.ready()`. Please use `@marp-team/marp-core/browser` entrypoint.

:warning: [Marp for VS Code](https://github.com/marp-team/marp-vscode) had tried to replace to use `@marp-team/marp-core/browser` but it did not work caused by rollup's bug (https://github.com/rollup/plugins/issues/102). Whether or not including it to v1 release is still considering.