### PR TITLE
Mark Marpit plugin interface as external in rollup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- v1.0.0 throws "z is not a function" ([#146](https://github.com/marp-team/marp-core/issues/146), [#147](https://github.com/marp-team/marp-core/pull/147))
+
 ## v1.0.0 - 2020-01-13
 
 ### Breaking

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -64,7 +64,7 @@ export default [
     plugins,
   },
   {
-    external: Object.keys(pkg.dependencies),
+    external: [...Object.keys(pkg.dependencies), '@marp-team/marpit/plugin'],
     input: `src/${path.basename(pkg.main, '.js')}.ts`,
     output: { exports: 'named', file: pkg.main, format: 'cjs' },
     plugins,


### PR DESCRIPTION
A bundled `@marp-team/marpit/plugin` by rollup has incorrect CommonJS resolving. (https://github.com/rollup/plugins/issues/102)

Marpit is already marked as external dependent module so plugin interface should follow too.

```js
> require('./lib/marp')
{
  Marp: [Function: cn] { html: { br: [] } },
  default: [Function: cn] { html: { br: [] } }
}
```

Fix #146.