### PR TITLE
Setup GitHub Dependabot for marp-team packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    reviewers:
+      - 'marp-team/maintainers'
+    schedule:
+      interval: daily
+    allow:
+      - dependency-name: '@marp-team/*'
+    versioning-strategy: increase
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    reviewers:
+      - 'marp-team/maintainers'
+    schedule:
+      interval: weekly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Setup GitHub Dependabot for marp-team packages ([#172](https://github.com/marp-team/marp-core/pull/172))
+
 ## v1.2.1 - 2020-07-09
 
 ### Added


### PR DESCRIPTION
Marp team is working to update dependencies regularly.

To save the time for routine work, we've set up GitHub Dependabot to update packages provided by @marp-team automatically. In addition, we have set up auto-update for GitHub actions too.

Notice that the auto-update for external packages is not setting up. These still have to update manually because may met some breaking changes.