### PR TITLE
Update browser script to make changeable the target root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade Marpit SVG polyfill to [v1.7.0](https://github.com/marp-team/marpit-svg-polyfill/releases/v1.7.0) ([#184](https://github.com/marp-team/marp-core/pull/184), [#185](https://github.com/marp-team/marp-core/pull/185))
+- Update browser script to make changeable the target root ([#185](https://github.com/marp-team/marp-core/pull/185))
+
+### Deprecated
+
+- `observe()` with boolean argument from `@marp-team/marp-core/browser` has been deprecated in favor of the usage of the option object ([#185](https://github.com/marp-team/marp-core/pull/185))
+
 ## v1.2.2 - 2020-07-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "@marp-team/marpit": "^1.6.2",
-    "@marp-team/marpit-svg-polyfill": "^1.5.0",
+    "@marp-team/marpit-svg-polyfill": "^1.7.0",
     "emoji-regex": "^9.0.0",
     "highlight.js": "^10.1.1",
     "katex": "^0.11.1",

--- a/scripts/browser.js
+++ b/scripts/browser.js
@@ -1,3 +1,5 @@
 import { browser } from '../src/browser'
 
-browser(document.currentScript.getRootNode())
+const script = document.currentScript
+
+browser(script ? script.getRootNode() : document)

--- a/scripts/browser.js
+++ b/scripts/browser.js
@@ -1,3 +1,3 @@
-import browser from '../src/browser'
+import { browser } from '../src/browser'
 
-browser()
+browser(document.currentScript.getRootNode())

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,19 +1,32 @@
-import observer from './observer'
-
+import { observer } from './observer'
 export { observer }
 
-export default function browser(): void {
+const marpCoreBrowserScript = Symbol()
+
+export const browser = (target: ParentNode = document): (() => void) => {
   if (typeof window === 'undefined') {
     throw new Error(
       "Marp Core's browser script is valid only in browser context."
     )
   }
 
-  if (window['marpCoreBrowserScript']) {
+  if (target[marpCoreBrowserScript]) {
     console.warn("Marp Core's browser script has already executed.")
-    return
+    return target[marpCoreBrowserScript]
   }
 
-  Object.defineProperty(window, 'marpCoreBrowserScript', { value: true })
-  observer()
+  const cleanupObserver = observer({ target })
+  const cleanup = () => {
+    cleanupObserver()
+    delete target[marpCoreBrowserScript]
+  }
+
+  Object.defineProperty(target, marpCoreBrowserScript, {
+    configurable: true,
+    value: cleanup,
+  })
+
+  return cleanup
 }
+
+export default browser

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -10,10 +10,7 @@ export const browser = (target: ParentNode = document): (() => void) => {
     )
   }
 
-  if (target[marpCoreBrowserScript]) {
-    console.warn("Marp Core's browser script has already executed.")
-    return target[marpCoreBrowserScript]
-  }
+  if (target[marpCoreBrowserScript]) return target[marpCoreBrowserScript]
 
   const cleanupObserver = observer({ target })
   const cleanup = () => {

--- a/src/fitting/observer.ts
+++ b/src/fitting/observer.ts
@@ -7,9 +7,9 @@ const updateAttr = (elm: Element, attr: string, value: string): true | void => {
   }
 }
 
-export default function fittingObserver(): void {
+export default function fittingObserver(target: ParentNode = document): void {
   Array.from(
-    document.querySelectorAll<HTMLElement>(`svg[${attr}="svg"]`),
+    target.querySelectorAll<HTMLElement>(`svg[${attr}="svg"]`),
     (svg) => {
       const foreignObject = svg.firstChild as SVGForeignObjectElement
       const container = foreignObject.firstChild as HTMLSpanElement

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,10 +1,45 @@
 import { polyfills } from '@marp-team/marpit-svg-polyfill'
 import fittingObserver from './fitting/observer'
 
-// Observer is divided for usage in Marp Web.
-export default function observer(keep = true): void {
-  for (const polyfill of polyfills()) polyfill()
-  fittingObserver()
-
-  if (keep) window.requestAnimationFrame(() => observer(keep))
+type ObserverOptions = {
+  once?: boolean
+  target?: ParentNode
 }
+
+export function observer(opts?: ObserverOptions): () => void
+/** @deprecated Usage of observer() with boolean option has been deprecated. Please replace with the usage of option object. */
+export function observer(keep?: boolean): () => void
+export function observer(opts: ObserverOptions | boolean = {}): () => void {
+  const _opts =
+    typeof opts === 'boolean'
+      ? ((keep): ObserverOptions => {
+          const once = !keep
+          console.warn(
+            `[DEPRECATION WARNING] Usage of observer() with boolean option has been deprecated. Please replace with the usage of option object: observer({ once: ${
+              once ? 'true' : 'false'
+            } }).`
+          )
+
+          return { once }
+        })(opts)
+      : opts
+
+  const { once = false, target = document } = _opts
+  const polyfillFuncs = polyfills()
+
+  let enabled = !once
+
+  const observer = () => {
+    for (const polyfill of polyfillFuncs) polyfill({ target })
+    fittingObserver(target)
+
+    if (enabled) window.requestAnimationFrame(observer)
+  }
+  observer()
+
+  return () => {
+    enabled = false
+  }
+}
+
+export default observer

--- a/src/script/browser-script.ts
+++ b/src/script/browser-script.ts
@@ -1,3 +1,4 @@
-const dummy = 'This is a placeholder for the content of built browser script.'
+const placeholder =
+  'This is a placeholder for the content of built browser script.'
 
-export default dummy
+export default placeholder

--- a/yarn.lock
+++ b/yarn.lock
@@ -581,10 +581,10 @@
     twemoji "^13.0.0"
     xss "^1.0.7"
 
-"@marp-team/marpit-svg-polyfill@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@marp-team/marpit-svg-polyfill/-/marpit-svg-polyfill-1.5.0.tgz#420db83762914e2dd0f0019300e2ba703deed0a0"
-  integrity sha512-1JksTIO/Kq3D2FxfoJaBs0Qcq/gvzQqGyEiVNJY+4NfOtUhkGzYyMfGa0ESAkfRCyFZqjrF3WinK+ZILppbJEA==
+"@marp-team/marpit-svg-polyfill@^1.5.0", "@marp-team/marpit-svg-polyfill@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@marp-team/marpit-svg-polyfill/-/marpit-svg-polyfill-1.7.0.tgz#cd4e26f2a66d487bb79db7ea5c651d21e7561d07"
+  integrity sha512-zgxLmO6ndj7DjYQqJ7i5Re62hkHFdx2j5xMa1plKeU3nmmpldXC4iBPTEuw2K/T3RBbgq9Dm2JViThKZSFbAMQ==
 
 "@marp-team/marpit@^1.6.2":
   version "1.6.2"


### PR DESCRIPTION
Updated browser script to make changeable the target root. It brings that Marp slides can render correctly within the shadow root (Web Components).

The target root will change depending on the root node of an injected script automatically.

If using module from `@marp-team/marp-core/browser`, developer can change the target by passing the node in first argument.

```javascript
import browser from '@marp-team/marp-core/browser`

// Apply to the shadow root
const container = document.querySelector('.marp-container')
const cleanup = browser(container.shadowRoot)
```

> `observe()`, a detailed interface, has changed the form of argument to object. A previous boolean argument has deprecated and will be transformed to corresponding option if used.