### PR TITLE
Math plugin: Better context handling for defined macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- KaTeX: Persist defined global macro between math renderings ([#212](https://github.com/marp-team/marp-core/pull/212))
+- MathJax: Prevent leaking defined macro between Markdown renderings ([#212](https://github.com/marp-team/marp-core/pull/212))
+
 ### Changed
 
 - Upgrade Marpit to [v1.6.4](https://github.com/marp-team/marpit/releases/v1.6.4) ([#210](https://github.com/marp-team/marp-core/pull/210))

--- a/src/math/context.ts
+++ b/src/math/context.ts
@@ -1,0 +1,26 @@
+import type { MathOptionsInterface } from './math'
+
+type MathContext = {
+  enabled: boolean
+  options: MathOptionsInterface
+
+  // Library specific contexts
+  katexMacroContext: Record<string, string>
+  mathjaxContext: any
+}
+
+const contextSymbol = Symbol('marp-math-context')
+
+export const setMathContext = (
+  target: any,
+  setter: (current: MathContext) => MathContext
+) => {
+  if (!Object.prototype.hasOwnProperty.call(target, contextSymbol)) {
+    Object.defineProperty(target, contextSymbol, { writable: true })
+  }
+  target[contextSymbol] = setter(target[contextSymbol])
+}
+
+export const getMathContext = (target: any): MathContext => ({
+  ...target[contextSymbol],
+})

--- a/src/math/katex.ts
+++ b/src/math/katex.ts
@@ -1,17 +1,23 @@
 import katex from 'katex'
 import { version } from 'katex/package.json'
+import { getMathContext } from './context'
 import katexScss from './katex.scss'
 
 const convertedCSS = Object.create(null)
 const katexMatcher = /url\(['"]?fonts\/(.*?)['"]?\)/g
 
-export const inline = (opts: Record<string, unknown> = {}) => (tokens, idx) => {
+export const inline = (marpit: any) => (tokens, idx) => {
   const { content } = tokens[idx]
+  const {
+    options: { katexOption },
+    katexMacroContext,
+  } = getMathContext(marpit)
 
   try {
     return katex.renderToString(content, {
       throwOnError: false,
-      ...opts,
+      ...(katexOption || {}),
+      macros: katexMacroContext,
       displayMode: false,
     })
   } catch (e) {
@@ -20,13 +26,18 @@ export const inline = (opts: Record<string, unknown> = {}) => (tokens, idx) => {
   }
 }
 
-export const block = (opts: Record<string, unknown> = {}) => (tokens, idx) => {
+export const block = (marpit: any) => (tokens, idx) => {
   const { content } = tokens[idx]
+  const {
+    options: { katexOption },
+    katexMacroContext,
+  } = getMathContext(marpit)
 
   try {
     return `<p>${katex.renderToString(content, {
       throwOnError: false,
-      ...opts,
+      ...(katexOption || {}),
+      macros: katexMacroContext,
       displayMode: true,
     })}</p>`
   } catch (e) {


### PR DESCRIPTION
Updated Marp Core Math plugin to make better context handling of math rendering. Fix problems about defined macro.

- KaTeX: Persist defined global macro between math renderings.

> `\gdef`, `\xdef`, `\global\def`, `\global\edef`, `\global\let`, and `\global\futurelet` will persist between math expressions.
>
> _-- https://katex.org/docs/supported.html#macros_

- MathJax: Prevent leaking defined macro between Markdown renderings.

Resolve marp-team/marp#71.