### PR TITLE
Don't reset math context in markdown-it parse functions while in rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- KaTeX does not be rendered together with header/footer ([#214](https://github.com/marp-team/marp-core/issues/214), [#215](https://github.com/marp-team/marp-core/pull/215))
+
 ## v1.4.2 - 2021-02-07
 
 ### Changed

--- a/src/math/context.ts
+++ b/src/math/context.ts
@@ -1,8 +1,14 @@
 import type { MathOptionsInterface } from './math'
 
 type MathContext = {
+  /** Whether Markdown is using math syntax  */
   enabled: boolean
+
+  /** Math options that have passed into Marp Core instance */
   options: MathOptionsInterface
+
+  /** Whether Math plugin is processing in the context for current render */
+  processing: boolean
 
   // Library specific contexts
   katexMacroContext: Record<string, string>


### PR DESCRIPTION
Add `processing` key into math plugin context to store whether in rendering. Math plugin has reseted math context when calling markdown-it's `parse()` and `parseInline()` functions, but must not reset that if a rendering has already processed.

Fix #214. Marpit is internally using `parseInline()` within the process of `parse()`, to render header and footer.