### PR TITLE
Allow color customization through CSS variables in Gaia and Uncover theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Upgrade Marpit to [v2.0.0](https://github.com/marp-team/marpit/releases/v2.0.0) ([#220](https://github.com/marp-team/marp-core/pull/220))
+- Allow color customization through CSS variables in Gaia and Uncover theme ([#209](https://github.com/marp-team/marp-core/issues/209), [#221](https://github.com/marp-team/marp-core/pull/221))
 
 ## v1.5.0 - 2021-04-02
 

--- a/marp.config.js
+++ b/marp.config.js
@@ -5,4 +5,7 @@ module.exports = {
   engine,
   server: true,
   inputDir: path.join(__dirname, './sandbox'),
+  options: {
+    minifyCSS: false,
+  },
 }

--- a/themes/README.md
+++ b/themes/README.md
@@ -102,6 +102,23 @@ Gaia theme supports an additional color scheme by `gaia` class.
 > # Lead + gaia
 > ```
 
+### Custom color (CSS variables)
+
+Color scheme for Gaia theme has defined by CSS variables. You also can use the custom color scheme by inline style.
+
+```html
+<style>
+  :root {
+    --color-background: #fff !important;
+    --color-foreground: #333 !important;
+    --color-highlight: #f96 !important;
+    --color-dimmed: #888 !important;
+  }
+</style>
+```
+
+`!important` is required to make custom colors force against specific color defined by HTML classes like `invert` and `gaia`. See also: [marp-team/marp-core#221](https://github.com/marp-team/marp-core/pull/221)
+
 ## Uncover
 
 [![](https://user-images.githubusercontent.com/3993388/48039495-5456b200-e1b8-11e8-8c82-ca7f7842b34d.png)][example]
@@ -115,7 +132,29 @@ Uncover theme has three design concepts: simple, minimal, and modern. It's inspi
 
 ### :warning: Restrictions
 
-[Auto-scaling for code block](https://github.com/marp-team/marp-core#auto-scaling-features) is disabled because uncover theme uses the elastic style that has not compatible with it.
+_[Auto-scaling for code block](https://github.com/marp-team/marp-core#auto-scaling-features) is disabled_ because uncover theme uses the elastic style that has not compatible with it.
+
+### Custom color (CSS variables)
+
+Color scheme for Uncover theme has defined by CSS variables. You also can use the custom color scheme by inline style.
+
+```html
+<style>
+  :root {
+    --color-background: #ddd !important;
+    --color-background-code: #ccc !important;
+    --color-background-paginate: rgba(128, 128, 128, 0.05) !important;
+    --color-foreground: #345 !important;
+    --color-highlight: #99c !important;
+    --color-highlight-hover: #aaf !important;
+    --color-highlight-heading: #99c !important;
+    --color-header: #bbb !important;
+    --color-header-shadow: transparent !important;
+  }
+</style>
+```
+
+`!important` is required to make custom colors force against specific color defined by HTML classes like `invert`. See also: [marp-team/marp-core#221](https://github.com/marp-team/marp-core/pull/221)
 
 # Metadata for additional features
 

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -17,60 +17,11 @@ $color-secondary: #81d4fa;
 @import '~highlight.js/styles/sunburst';
 
 @mixin color-scheme($bg, $text, $highlight) {
-  color: $text;
-  background-color: $bg;
-
-  a,
-  mark {
-    color: $highlight;
-  }
-
-  code {
-    background: mix($text, $bg, 80%);
-    color: $bg;
-  }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    strong {
-      color: $highlight;
-    }
-  }
-
-  pre > code {
-    background: $text;
-  }
-
-  header,
-  footer,
-  section::after,
-  blockquote::before,
-  blockquote::after {
-    color: mix($text, $bg, 80%);
-  }
-
-  table {
-    th,
-    td {
-      border-color: $text;
-    }
-
-    thead th {
-      background: $text;
-      color: $bg;
-    }
-
-    tbody > tr:nth-child(odd) {
-      td,
-      th {
-        background: rgba($text, 0.1);
-      }
-    }
-  }
+  --color-background: #{$bg};
+  --color-background-stripe: #{rgba($text, 0.1)};
+  --color-foreground: #{$text};
+  --color-dimmed: #{mix($text, $bg, 80%)};
+  --color-highlight: #{$highlight};
 }
 
 svg[data-marp-fitting='svg'] {
@@ -206,7 +157,32 @@ table {
   }
 }
 
+header,
+footer,
+section::after {
+  box-sizing: border-box;
+  font-size: 66%;
+  height: 70px;
+  line-height: 50px;
+  overflow: hidden;
+  padding: 10px 25px;
+  position: absolute;
+}
+
+header {
+  left: 0;
+  right: 0;
+  top: 0;
+}
+
+footer {
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
 section {
+  background-color: var(--color-background);
   background-image: linear-gradient(
     135deg,
     rgba(#888, 0),
@@ -214,6 +190,7 @@ section {
     rgba(#fff, 0) 50%,
     rgba(#fff, 0.05)
   );
+  color: var(--color-foreground);
   font-size: 35px;
   font-family: 'Lato', 'Avenir Next', 'Avenir', 'Trebuchet MS', 'Segoe UI',
     sans-serif;
@@ -224,12 +201,70 @@ section {
   width: 1280px;
   word-wrap: break-word;
 
+  @include color-scheme($color-light, $color-dark, $color-primary);
+
+  &::after {
+    right: 0;
+    bottom: 0;
+    font-size: 80%;
+  }
+
+  a,
+  mark {
+    color: var(--color-highlight);
+  }
+
+  code {
+    background: var(--color-dimmed);
+    color: var(--color-background);
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    strong {
+      color: var(--color-highlight);
+    }
+  }
+
+  pre > code {
+    background: var(--color-foreground);
+  }
+
+  header,
+  footer,
+  section::after,
+  blockquote::before,
+  blockquote::after {
+    color: var(--color-dimmed);
+  }
+
+  table {
+    th,
+    td {
+      border-color: var(--color-foreground);
+    }
+
+    thead th {
+      background: var(--color-foreground);
+      color: var(--color-background);
+    }
+
+    tbody > tr:nth-child(odd) {
+      td,
+      th {
+        background: var(--color-background-stripe, transparent);
+      }
+    }
+  }
+
   > *:first-child,
   > header:first-child + * {
     margin-top: 0;
   }
-
-  @include color-scheme($color-light, $color-dark, $color-primary);
 
   &.invert {
     @include color-scheme($color-dark, $color-light, $color-secondary);
@@ -290,34 +325,4 @@ section {
       margin-right: auto;
     }
   }
-}
-
-header,
-footer,
-section::after {
-  box-sizing: border-box;
-  font-size: 66%;
-  height: 70px;
-  line-height: 50px;
-  overflow: hidden;
-  padding: 10px 25px;
-  position: absolute;
-}
-
-header {
-  left: 0;
-  right: 0;
-  top: 0;
-}
-
-footer {
-  left: 0;
-  right: 0;
-  bottom: 0;
-}
-
-section::after {
-  right: 0;
-  bottom: 0;
-  font-size: 80%;
 }

--- a/themes/uncover.scss
+++ b/themes/uncover.scss
@@ -9,60 +9,20 @@
  */
 
 @mixin color-scheme($bg: #fdfcff, $text: #202228, $highlight: #009dd5) {
-  background: $bg;
-  color: $text;
-
-  &::after {
-    /*
-     * Gradient with hard stops has incorrect rendering in Firefox's PDF.js
-     * @see https://github.com/mozilla/pdf.js/issues/10572
-     */
-    // background: linear-gradient(-45deg, rgba($text, 0.05) 50%, transparent 50%);
-    background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 1 1" width="1" height="1"><path d="M0 1h1v-1Z" fill="#{rgba($text, 0.05)}"/></svg>')
-      no-repeat center center;
-    background-size: cover;
-    color: $text;
-    text-shadow: 0 0 5px $bg;
-  }
-
-  pre,
-  code {
-    background: mix($bg, $text, 95%);
-    color: $text;
-  }
-
-  a {
-    color: $highlight;
-
-    &:hover {
-      color: mix($text, $highlight, 25%);
-    }
-  }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    strong {
-      color: mix(#fff, $highlight, 20%);
-    }
-  }
-
-  header,
-  footer {
-    color: rgba($text, 0.4);
-    text-shadow: 0 1px 0 rgba($bg, 0.8);
-  }
-
-  mark {
-    color: $highlight;
-    background: transparent;
-  }
+  --color-background: #{$bg};
+  --color-background-code: #{mix($bg, $text, 95%)};
+  --color-background-paginate: #{rgba($text, 0.05)};
+  --color-foreground: #{$text};
+  --color-highlight: #{$highlight};
+  --color-highlight-hover: #{mix($text, $highlight, 25%)};
+  --color-highlight-heading: #{mix(#fff, $highlight, 20%)};
+  --color-header: #{rgba($text, 0.4)};
+  --color-header-shadow: #{rgba($bg, 0.8)};
 }
 
 section {
+  background: var(--color-background);
+  color: var(--color-foreground);
   display: flex;
   flex-direction: column;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
@@ -82,12 +42,20 @@ section {
 
   &::after {
     align-items: flex-end;
+    background: linear-gradient(
+      -45deg,
+      var(--color-background-paginate) 50%,
+      transparent 50%
+    );
+    background-size: cover;
+    color: var(--color-foreground);
     display: flex;
     font-size: 0.6em;
     height: 80px;
     justify-content: flex-end;
     padding: 30px;
     text-align: right;
+    text-shadow: 0 0 5px var(--color-background);
     width: 80px;
   }
 
@@ -132,6 +100,7 @@ section {
     margin: 15px 0 30px 0;
 
     strong {
+      color: var(--color-highlight-heading);
       font-weight: inherit;
     }
   }
@@ -166,12 +135,14 @@ section {
 
   header,
   footer {
-    position: absolute;
-    z-index: 1;
-    left: 70px;
-    right: 70px;
+    color: var(--color-header);
     font-size: 0.45em;
+    left: 70px;
     letter-spacing: 1px;
+    position: absolute;
+    right: 70px;
+    text-shadow: 0 1px 0 var(--color-header-shadow);
+    z-index: 1;
   }
 
   header {
@@ -183,9 +154,11 @@ section {
   }
 
   a {
+    color: var(--color-highlight);
     text-decoration: none;
 
     &:hover {
+      color: var(--color-highlight-hover);
       text-decoration: underline;
     }
   }
@@ -203,6 +176,8 @@ section {
 
   pre,
   code {
+    background: var(--color-background-code);
+    color: var(--color-foreground);
     font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier,
       monospace;
     letter-spacing: 0;
@@ -285,5 +260,10 @@ section {
     > *:last-child {
       margin-bottom: 0;
     }
+  }
+
+  mark {
+    color: var(--color-highlight);
+    background: transparent;
   }
 }


### PR DESCRIPTION
Allowed color customization through CSS variables, in `gaia` theme and `uncover` theme.

Related: #209.

## Usage

### Gaia theme

```markdown
---
theme: gaia
style: |
  :root {
    --color-background: #fff !important;
    --color-foreground: #333 !important;
    --color-highlight: #f96 !important;
    --color-dimmed: #888 !important;
  }
---
```

### Uncover theme

```markdown
---
theme: uncover
style: |
  :root {
    --color-background: #ddd;
    --color-background-code: #ccc;
    --color-background-paginate: rgba(128, 128, 128, 0.05);
    --color-foreground: #345;
    --color-highlight: #99c;
    --color-highlight-hover: #aaf;
    --color-highlight-heading: #99c;
    --color-header: #bbb;
    --color-header-shadow: transparent;
  }
---
```

`!important` is required to make custom colors force, against specified color via HTML class like `invert` and `gaia`.

## ToDo

- ~[ ] Default theme~
  - Marp default theme is depending on [`github-markdown-css`](https://github.com/sindresorhus/github-markdown-css) and it is not provided variables-based color defintion as like as GitHub's dark mode. Current `invert` class has many unique definitions against the current GitHub dark mode. It seems wise to wait for the support of variables used by GitHub.
- [x] Gaia theme
- [x] Uncover theme