### PR TITLE
Add 16:9 preset definition to built-in themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Define the default 16:9 size preset to built-in themes ([#250](https://github.com/marp-team/marp-core/pull/250))
+
 ## v2.1.0 - 2021-07-19
 
 ### Added

--- a/themes/default.scss
+++ b/themes/default.scss
@@ -5,6 +5,7 @@
  * @author Yuki Hattori
  *
  * @auto-scaling true
+ * @size 16:9 1280px 720px
  * @size 4:3 960px 720px
  */
 

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -5,6 +5,7 @@
  * @author Yuki Hattori
  *
  * @auto-scaling true
+ * @size 16:9 1280px 720px
  * @size 4:3 960px 720px
  */
 

--- a/themes/uncover.scss
+++ b/themes/uncover.scss
@@ -5,6 +5,7 @@
  * @author Yuki Hattori
  *
  * @auto-scaling fittingHeader,math
+ * @size 16:9 1280px 720px
  * @size 4:3 960px 720px
  */
 


### PR DESCRIPTION
Added the default preset `16:9` for auto-completion by marp-vscode.

It should never affect to existing slides.