### PR TITLE
Adopt `::where` selector to class variants for making styles overrideable

### DIFF
--- a/scripts/postcss-optimize-default-theme.js
+++ b/scripts/postcss-optimize-default-theme.js
@@ -18,8 +18,6 @@ const plugin = () => {
         const matched = rule.params.match(colorThemeMatcher)
 
         if (matched) {
-          rule.params = 'all'
-
           if (matched[1] === 'dark') {
             rule.walkRules((rule) => {
               postcssSelectorParser((selectorRoot) => {
@@ -29,13 +27,17 @@ const plugin = () => {
                   if (normalizedTagName === 'section') {
                     tag.parent.insertAfter(
                       tag,
-                      postcssSelectorParser.className({ value: 'invert' })
+                      postcssSelectorParser.pseudo({ value: ':where(.invert)' })
                     )
                   }
                 })
               }).processSync(rule, { updateSelector: true })
             })
+
+            // Append a rule of dark theme after the light theme
+            rule.next().after(rule.nodes)
           }
+          rule.replaceWith(rule.nodes)
         }
       },
     },

--- a/themes/default.scss
+++ b/themes/default.scss
@@ -199,6 +199,13 @@ section {
   padding: 78.5px;
   width: 1280px;
 
+  &:where(.invert) {
+    --h1-color: #cee7ff;
+    --header-footer-color: #{rgba(#999, 0.75)};
+    --heading-strong-color: #7bf;
+    --paginate-color: #999;
+  }
+
   > *:last-child,
   &[data-footer] > :nth-last-child(2) {
     margin-bottom: 0;
@@ -216,13 +223,6 @@ section {
     bottom: 21px;
     font-size: 24px;
     color: var(--paginate-color);
-  }
-
-  &.invert {
-    --h1-color: #cee7ff;
-    --header-footer-color: #{rgba(#999, 0.75)};
-    --heading-strong-color: #7bf;
-    --paginate-color: #999;
   }
 
   &[data-color] {

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -272,15 +272,15 @@ section {
     margin-top: 0;
   }
 
-  &.invert {
+  &:where(.invert) {
     @include color-scheme($color-dark, $color-light, $color-secondary);
   }
 
-  &.gaia {
+  &:where(.gaia) {
     @include color-scheme($color-primary, $color-light, $color-secondary);
   }
 
-  &.lead {
+  &:where(.lead) {
     display: flex;
     flex-flow: column nowrap;
     justify-content: center;

--- a/themes/uncover.scss
+++ b/themes/uncover.scss
@@ -63,11 +63,11 @@ section {
 
   @include color-scheme;
 
-  &:not(.invert) {
+  &:where(:not(.invert)) {
     @import '~highlight.js/styles/color-brewer';
   }
 
-  &.invert {
+  &:where(.invert) {
     @include color-scheme(#202228, #fff, #60d0f0);
     @import '~highlight.js/styles/codepen-embed';
   }
@@ -196,6 +196,10 @@ section {
     line-height: 1.15;
     margin: 15px 0 30px;
     text-align: left;
+
+    &::part(auto-scaling) {
+      max-height: 570px;
+    }
   }
 
   pre > code {

--- a/v3.md
+++ b/v3.md
@@ -13,3 +13,4 @@
 
 - New auto-scaling based on Web Components ([#96](https://github.com/marp-team/marp-core/issues/96), [#248](https://github.com/marp-team/marp-core/issues/248), [#263](https://github.com/marp-team/marp-core/pull/263))
 - Match color schemes for `default` theme to the latest GitHub ([#266](https://github.com/marp-team/marp-core/issues/266))
+- Adopt `::where()` selector to class variants for making styles overridable ([#244](https://github.com/marp-team/marp-core/issues/244), [#267](https://github.com/marp-team/marp-core/pull/267))


### PR DESCRIPTION
Changed to use `:where()` selector for defining the built-in themes class variants such as `invert`. It makes variant styles overrideable through `<style>` inline style by the Markdown author easily.

### v2

```markdown
<!-- class: invert -->

<style>
section {
  /* ❗️ This override will not work unless using !important */
  background: gray;
}
</style>

Invert variant
```

### v3


```markdown
<!-- class: invert -->

<style>
section {
  background: gray;
}
</style>

Invert variant
```

Related: #244