### PR TITLE
Disable autolink without protocol `http(s)://`

### DIFF
--- a/src/marp.ts
+++ b/src/marp.ts
@@ -60,9 +60,11 @@ export class Marp extends Marpit {
     } as MarpOptions)
 
     this.markdown.enable(['table', 'linkify', 'strikethrough'])
+    this.markdown.linkify.set({ fuzzyLink: false })
 
-    if (mdOpts.typographer)
+    if (mdOpts.typographer) {
       this.markdown.enable(['replacements', 'smartquotes'])
+    }
 
     // Theme support
     this.themeSet.metaType = Object.freeze({

--- a/v3.md
+++ b/v3.md
@@ -11,6 +11,7 @@
 
 ### Changed
 
-- New auto-scaling based on Web Components ([#96](https://github.com/marp-team/marp-core/issues/96), [#248](https://github.com/marp-team/marp-core/issues/248), [#263](https://github.com/marp-team/marp-core/pull/263))
+- Web Components based new auto scaling ([#96](https://github.com/marp-team/marp-core/issues/96), [#248](https://github.com/marp-team/marp-core/issues/248), [#263](https://github.com/marp-team/marp-core/pull/263))
 - Match color schemes for `default` theme to the latest GitHub ([#266](https://github.com/marp-team/marp-core/issues/266))
 - Adopt `::where()` selector to class variants for making styles overridable ([#244](https://github.com/marp-team/marp-core/issues/244), [#267](https://github.com/marp-team/marp-core/pull/267))
+- Disable autolink for URL text that has no `http(s)://` protocol ([#268](https://github.com/marp-team/marp-core/pull/268))


### PR DESCRIPTION
Disabled the autolink that the text has no protocol such as `http://` and `https://`. It can prevent unwanted autolink in some texts such as `ASP.NET` and `ML.NET`.
