### PR TITLE
Change the default math library from `katex` to `mathjax`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,24 @@ const { html, css } = marp.render('# Hello, marp-core!')
 
 ## Features
 
-_We will only explain features extended in marp-core._ Please refer to [@marp-team/marpit](https://github.com/marp-team/marpit) repository if you want to know the basic feature of Marpit framework.
+_We will only explain features extended in marp-core._ Please refer to [Marpit framework](https://marpit.marp.app) if you want to know the basic features.
+
+---
 
 ### Marp Markdown
 
-Marp Markdown is based on [Marpit](https://github.com/marp-team/marpit) and [CommonMark](https://commonmark.org/), and there are these additional features:
+**Marp Markdown** is a custom Markdown flavor based on [Marpit](https://marpit.marp.app) and [CommonMark](https://commonmark.org/). Following are principle differences from the original:
 
 - **Marpit**
-  - Enable [inline SVG mode](https://github.com/marp-team/marpit#inline-svg-slide-experimental) and loose YAML parsing by default.
+  - Enabled [inline SVG slide](https://marpit.marp.app/inline-svg) and [loose YAML parsing](https://marpit-api.marp.app/marpit#Marpit) by default.
 
 * **CommonMark**
-  - For security reason, HTML tag only allows `<br />` by default.
+  - For making secure, we will deny most of HTML tags used in Markdown (`<br>` is only allowed by default).
   - Support [table](https://github.github.com/gfm/#tables-extension-) and [strikethrough](https://github.github.com/gfm/#strikethrough-extension-) syntax, based on [GitHub Flavored Markdown](https://github.github.com/gfm/).
   - Line breaks in paragraph will convert to `<br>` tag.
-  - Auto convert URL like text into hyperlink.
+  - Convert URL-like text into hyperlink automatically.
+
+---
 
 ### [Built-in official themes][themes]
 
@@ -49,9 +53,11 @@ We provide bulit-in official themes for Marp. See more details in [themes].
 
 [themes]: ./themes/
 
+---
+
 ### `size` global directive
 
-Do you want a traditional 4:3 slide size? We've added the support of `size` global directive only for Marp Core. Our extended theming system can use `960`x`720` slide in built-in themes easier: `size: 4:3`.
+Do you want a traditional 4:3 slide size? Marp Core adds the support of `size` global directive. The extended theming system can switch the slide size easier.
 
 ```markdown
 ---
@@ -62,15 +68,23 @@ size: 4:3
 # A traditional 4:3 slide
 ```
 
-If you want to use more size presets in your theme, you have to define `@size` metadata(s) in theme CSS. [Learn in the document of theme metadata for Marp Core][metadata].
+[Bulit-in themes for Marp][themes] have provided `16:9` (1280x720) and `4:3` (960x720) preset sizes.
+
+#### Define size presets in custom theme CSS
+
+If you want to use more size presets in your own theme, you have to define `@size` metadata(s) in theme CSS. [Learn in the document of theme metadata for Marp Core][metadata].
 
 Theme author does not have to worry an unintended design being used with unexpected slide size because user only can use pre-defined presets by author.
 
 [metadata]: ./themes#metadata-for-additional-features
 
+---
+
 ### Emoji support
 
 Emoji shortcode (like `:smile:`) and Unicode emoji 😄 will convert into the SVG vector image provided by [twemoji](https://github.com/twitter/twemoji) <img src="https://twemoji.maxcdn.com/2/svg/1f604.svg" alt="😄" width="16" height="16" />. It could render emoji with high resolution.
+
+---
 
 ### Math typesetting
 
@@ -102,24 +116,24 @@ $$
 </td>
 <td>
 
-![Math typesetting support](https://user-images.githubusercontent.com/3993388/44745975-26177f00-ab44-11e8-9951-ebf8031ab009.png)
+![Math typesetting support](https://user-images.githubusercontent.com/3993388/142782335-15bce585-68f1-4c89-8747-8d11533f3ca6.png)
 
 </td>
 </tbody>
 </table>
 
-You can choose using library for math from [KaTeX](https://khan.github.io/KaTeX/) and [MathJax](https://www.mathjax.org/) in [`math` global directive](#math-global-directive) (or [JS constructor option](#math-constructor-option)). By default, we prefer KaTeX for compatibility and performance, but MathJax has better rendering and syntax support than KaTeX.
+You can choose using library for math from [MathJax](https://www.mathjax.org/) and [KaTeX](https://khan.github.io/KaTeX/) in [`math` global directive](#math-global-directive) (or [JS constructor option](#math-constructor-option)). By default, we prefer MathJax for better rendering and syntax support, but KaTeX is faster rendering if you had a lot of formulas.
 
 #### `math` global directive
 
 Through `math` global directive, Marp Core is supporting to declare math library that will be used within current Markdown.
 
-Set **`katex`** or **`mathjax`** in the `math` global directive like this:
+Set **`mathjax`** or **`katex`** in the `math` global directive like this:
 
 ```markdown
 ---
-# Declare to use MathJax in this Markdown
-math: mathjax
+# Declare to use KaTeX in this Markdown
+math: katex
 ---
 
 $$
@@ -130,18 +144,20 @@ x &= 1+1 \tag{1} \\
 $$
 ```
 
-If not declared, Marp Core will use the default library to render math (KaTeX in v2).
+If not declared, Marp Core will use the default library to render math. (MathJax in v3)
 
-We may change the default in the future and would break existing slides, so recommend to declare the library whenever to use math typesetting.
+To prevent breaking the slide in upcoming updates, recommend to declare the library whenever to use math typesetting.
 
 > :warning: The declaration of math library is given priority over [`math` JS constructor option](#math-constructor-option), but you cannot turn on again via `math` global directive if disabled math typesetting by the constructor.
+
+---
 
 ### Auto-scaling features
 
 Marp Core has some auto-scaling features:
 
 - [**Fitting header**](#fitting-header): Get bigger heading that fit onto the slide by `# <!--fit-->`.
-- [**Auto-shrink code and math block**](#auto-shrink-block): Prevent sticking out the block from the right of the slide.
+- [**Auto-shrink the code block and KaTeX block**](#auto-shrink-block): Prevent sticking out the block from the right of the slide.
 
 Auto-scaling is available if defined [`@auto-scaling` metadata][metadata] in an using theme CSS.
 
@@ -152,11 +168,11 @@ Auto-scaling is available if defined [`@auto-scaling` metadata][metadata] in an 
  */
 ```
 
-All of Marp Core's built-in themes are ready to use full-featured auto scalings. If you're the theme author, you can control target elements which enable auto-scaling [by using metadata keyword(s).][metadata]
+All of [Marp Core's built-in themes][themes] are ready to use full-featured auto scalings. If you're the theme author, you can control target elements which enable auto-scaling [by using metadata keyword(s).][metadata]
 
 This feature depends to inline SVG, so note that it will not working if disabled [Marpit's `inlineSVG` mode](https://github.com/marp-team/marpit#inline-svg-slide-experimental) by setting `inlineSVG: false` in constructor option.
 
-> :warning: Marp Core won't detect whether the elements actually protrude from the slide. It might still stick out from the slide edge if there are a lot of elements.
+> :warning: Auto-scaling is designed for horizontal scaling. In vertical, the scaled element still may stick out from top and bottom of slide if there are a lot of contents around it.
 
 #### Fitting header
 
@@ -168,7 +184,7 @@ When the headings contains `<!-- fit -->` comment, the size of headings will res
 
 This syntax is similar to [Deckset's `[fit]` keyword](https://docs.decksetapp.com/English.lproj/Formatting/01-headings.html), but we use HTML comment to hide a fit keyword on Markdown rendered as document.
 
-#### Auto-shrink block
+#### Auto-shrink the block
 
 Some of blocks will be shrunk to fit onto the slide. It is useful preventing stuck out the block from the right of the slide.
 
@@ -176,6 +192,10 @@ Some of blocks will be shrunk to fit onto the slide. It is useful preventing stu
 | :------------------: | :----------------------------------------------: | :-------------------------------------: |
 |    **Code block**    | ![Traditional rendering](https://bit.ly/2LyEnmi) | ![Auto-scaling](https://bit.ly/2N4yWQZ) |
 | **KaTeX math block** | ![Traditional rendering](https://bit.ly/2NXoHuW) | ![Auto-scaling](https://bit.ly/2M6LyCk) |
+
+> :information_source: MathJax math block will always be scaled without even setting `@auto-scaling` metadata.
+
+---
 
 ## Constructor options
 
@@ -194,7 +214,7 @@ const marp = new Marp({
       base: '/resources/twemoji/',
     },
   },
-  math: 'mathjax',
+  math: 'katex',
   minifyCSS: true,
   script: {
     source: 'cdn',
@@ -237,7 +257,7 @@ By passing `object`, you can set the allowlist to specify allowed tags and attri
 
 Marp core allows only `<br>` tag by default, that is defined in [`Marp.html`](https://github.com/marp-team/marp-core/blob/5c3593320f1c1234f3b2556ecd1ff1f91d69c77a/src/marp.ts#L45).
 
-Whatever any option is selected, `<!-- HTML comment -->` and `<style>` tag are always parsed for directives / tweaking style.
+> Whatever any option is selected, `<!-- HTML comment -->` and `<style>` tags are always parsed by Marpit for directives / tweaking style.
 
 ### `emoji`: _`object`_
 
@@ -258,14 +278,14 @@ Setting about emoji conversions.
 
 > **For developers:** When you setting `unicode` option as `true`, Markdown parser will convert Unicode emoji into tokens internally. The rendering result is same as in `false`.
 
-### `math`: _`boolean` | `"katex"` | `"mathjax"` | `object`_ <a name="math-constructor-option" id="math-constructor-option"></a>
+### `math`: _`boolean` | `"mathjax"` | `"katex"` | `object`_ <a name="math-constructor-option" id="math-constructor-option"></a>
 
 Enable or disable [math typesetting](#math-typesetting) syntax and [`math` global directive](#math-global-directive).
 
-You can choose the default library for math by passing **`"katex"`** (default) or **`"mathjax"`**, and modify more settings by passing an object of sub-options.
+You can choose the default library for math by passing **`"mathjax"`** (default) or **`"katex"`**, and modify more settings by passing an object of sub-options.
 
-- **`lib`**: _`"katex"` | `"mathjax"`_
-  - Choose the default library for math typesetting. _(`katex` by default)_
+- **`lib`**: _`"mathjax"` | `"katex"`_
+  - Choose the default library for math typesetting. _(`mathjax` by default)_
 
 * **`katexOption`**: _`object`_
   - Options that will be passed to KaTeX. Please refer to [KaTeX document](https://khan.github.io/KaTeX/docs/options.html).

--- a/test/__snapshots__/marp.ts.snap
+++ b/test/__snapshots__/marp.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Marp math option with KaTeX (default) injects KaTeX css with replacing web font URL to CDN: katex-css-cdn 1`] = `
+exports[`Marp math option with KaTeX injects KaTeX css with replacing web font URL to CDN: katex-css-cdn 1`] = `
 Array [
   "url('https://cdn.jsdelivr.net/npm/katex@0.13.23/dist/fonts/KaTeX_AMS-Regular.woff2') format(\\"woff2\\"),url('https://cdn.jsdelivr.net/npm/katex@0.13.23/dist/fonts/KaTeX_AMS-Regular.woff') format(\\"woff\\"),url('https://cdn.jsdelivr.net/npm/katex@0.13.23/dist/fonts/KaTeX_AMS-Regular.ttf') format(\\"truetype\\")",
   "url('https://cdn.jsdelivr.net/npm/katex@0.13.23/dist/fonts/KaTeX_Caligraphic-Bold.woff2') format(\\"woff2\\"),url('https://cdn.jsdelivr.net/npm/katex@0.13.23/dist/fonts/KaTeX_Caligraphic-Bold.woff') format(\\"woff\\"),url('https://cdn.jsdelivr.net/npm/katex@0.13.23/dist/fonts/KaTeX_Caligraphic-Bold.ttf') format(\\"truetype\\")",
@@ -25,7 +25,7 @@ Array [
 ]
 `;
 
-exports[`Marp math option with KaTeX (default) with katexFontPath as false does not replace KaTeX web font URL: katex-css-noops 1`] = `
+exports[`Marp math option with KaTeX with katexFontPath as false does not replace KaTeX web font URL: katex-css-noops 1`] = `
 Array [
   "url(fonts/KaTeX_AMS-Regular.woff2) format(\\"woff2\\"),url(fonts/KaTeX_AMS-Regular.woff) format(\\"woff\\"),url(fonts/KaTeX_AMS-Regular.ttf) format(\\"truetype\\")",
   "url(fonts/KaTeX_Caligraphic-Bold.woff2) format(\\"woff2\\"),url(fonts/KaTeX_Caligraphic-Bold.woff) format(\\"woff\\"),url(fonts/KaTeX_Caligraphic-Bold.ttf) format(\\"truetype\\")",
@@ -50,7 +50,7 @@ Array [
 ]
 `;
 
-exports[`Marp math option with KaTeX (default) with katexFontPath replaces KaTeX web font URL with specified path: katex-css-replace 1`] = `
+exports[`Marp math option with KaTeX with katexFontPath replaces KaTeX web font URL with specified path: katex-css-replace 1`] = `
 Array [
   "url('/resources/fonts/KaTeX_AMS-Regular.woff2') format(\\"woff2\\"),url('/resources/fonts/KaTeX_AMS-Regular.woff') format(\\"woff\\"),url('/resources/fonts/KaTeX_AMS-Regular.ttf') format(\\"truetype\\")",
   "url('/resources/fonts/KaTeX_Caligraphic-Bold.woff2') format(\\"woff2\\"),url('/resources/fonts/KaTeX_Caligraphic-Bold.woff') format(\\"woff\\"),url('/resources/fonts/KaTeX_Caligraphic-Bold.ttf') format(\\"truetype\\")",

--- a/test/math/__snapshots__/katex.ts.snap
+++ b/test/math/__snapshots__/katex.ts.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`markdown-it math plugin allows to place text immediately after inline math 1`] = `
+exports[`markdown-it math plugin for KaTeX allows to place text immediately after inline math 1`] = `
 "<p><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mi>n</mi></mrow><annotation encoding=\\"application/x-tex\\">n</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.43056em;\\"></span><span class=\\"mord mathnormal\\">n</span></span></span></span>-th order</p>
 "
 `;
 
-exports[`markdown-it math plugin can appear both maths in lists 1`] = `
+exports[`markdown-it math plugin for KaTeX can appear both maths in lists 1`] = `
 "<ul>
 <li><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">2</span></span></span></span></li>
 <li>
@@ -15,23 +15,23 @@ exports[`markdown-it math plugin can appear both maths in lists 1`] = `
 "
 `;
 
-exports[`markdown-it math plugin does not allow paragraph break in inline math 1`] = `
+exports[`markdown-it math plugin for KaTeX does not allow paragraph break in inline math 1`] = `
 "<p>foo $1+1</p>
 <p>= 2$ bar</p>
 "
 `;
 
-exports[`markdown-it math plugin does not process apparent markup in inline math 1`] = `
+exports[`markdown-it math plugin for KaTeX does not process apparent markup in inline math 1`] = `
 "<p>foo <span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mn>1</mn><mo>∗</mo><mi>i</mi><mo>∗</mo><mn>1</mn></mrow><annotation encoding=\\"application/x-tex\\">1 *i* 1</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">∗</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.65952em;\\"></span><span class=\\"mord mathnormal\\">i</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">∗</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span></span></span></span> bar</p>
 "
 `;
 
-exports[`markdown-it math plugin does not recognize inline block math 1`] = `
+exports[`markdown-it math plugin for KaTeX does not recognize inline block math 1`] = `
 "<p>It's well know that $$1 + 1 = 3$$ for sufficiently large 1.</p>
 "
 `;
 
-exports[`markdown-it math plugin does not render block math with indented up to 4 spaces (code block) 1`] = `
+exports[`markdown-it math plugin for KaTeX does not render block math with indented up to 4 spaces (code block) 1`] = `
 "<pre><code>$$
 1+1 = 2
 $$
@@ -39,7 +39,7 @@ $$
 "
 `;
 
-exports[`markdown-it math plugin does not render math when delimiters are escaped 1`] = `
+exports[`markdown-it math plugin for KaTeX does not render math when delimiters are escaped 1`] = `
 "<p>Foo $1$ bar
 $$
 1
@@ -47,56 +47,56 @@ $$</p>
 "
 `;
 
-exports[`markdown-it math plugin does not render math when numbers are followed closing inline math 1`] = `
+exports[`markdown-it math plugin for KaTeX does not render math when numbers are followed closing inline math 1`] = `
 "<p>Thus, $20,000 and USD$30,000 won't parse as math.</p>
 "
 `;
 
-exports[`markdown-it math plugin does not render with empty content 1`] = `
+exports[`markdown-it math plugin for KaTeX does not render with empty content 1`] = `
 "<p>aaa $$ bbb</p>
 "
 `;
 
-exports[`markdown-it math plugin recognizes escaped delimiters in math mode 1`] = `
+exports[`markdown-it math plugin for KaTeX recognizes escaped delimiters in math mode 1`] = `
 "<p>Money adds: <span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mi mathvariant=\\"normal\\">$</mi><mi>X</mi><mo>+</mo><mi mathvariant=\\"normal\\">$</mi><mi>Y</mi><mo>=</mo><mi mathvariant=\\"normal\\">$</mi><mi>Z</mi></mrow><annotation encoding=\\"application/x-tex\\">\\\\$X + \\\\$Y = \\\\$Z</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.83333em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">$</span><span class=\\"mord mathnormal\\" style=\\"margin-right:0.07847em;\\">X</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.80556em;vertical-align:-0.05556em;\\"></span><span class=\\"mord\\">$</span><span class=\\"mord mathnormal\\" style=\\"margin-right:0.22222em;\\">Y</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.80556em;vertical-align:-0.05556em;\\"></span><span class=\\"mord\\">$</span><span class=\\"mord mathnormal\\" style=\\"margin-right:0.07153em;\\">Z</span></span></span></span>.</p>
 "
 `;
 
-exports[`markdown-it math plugin recognizes multiline escaped delimiters in math module 1`] = `
+exports[`markdown-it math plugin for KaTeX recognizes multiline escaped delimiters in math module 1`] = `
 "<p>Weird-o: <span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mstyle scriptlevel=\\"0\\" displaystyle=\\"true\\"><mrow><mo fence=\\"true\\">(</mo><mtable rowspacing=\\"0.1600em\\" columnalign=\\"center center\\" columnspacing=\\"1em\\"><mtr><mtd><mstyle scriptlevel=\\"0\\" displaystyle=\\"false\\"><mi mathvariant=\\"normal\\">$</mi></mstyle></mtd><mtd><mstyle scriptlevel=\\"0\\" displaystyle=\\"false\\"><mn>1</mn></mstyle></mtd></mtr><mtr><mtd><mstyle scriptlevel=\\"0\\" displaystyle=\\"false\\"><mi mathvariant=\\"normal\\">$</mi></mstyle></mtd></mtr></mtable><mo fence=\\"true\\">)</mo></mrow></mstyle></mrow><annotation encoding=\\"application/x-tex\\">\\\\displaystyle{\\\\begin{pmatrix} \\\\$ &amp; 1\\\\\\\\\\\\$ \\\\end{pmatrix}}</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:2.40003em;vertical-align:-0.95003em;\\"></span><span class=\\"mord\\"><span class=\\"minner\\"><span class=\\"mopen delimcenter\\" style=\\"top:0em;\\"><span class=\\"delimsizing size3\\">(</span></span><span class=\\"mord\\"><span class=\\"mtable\\"><span class=\\"col-align-c\\"><span class=\\"vlist-t vlist-t2\\"><span class=\\"vlist-r\\"><span class=\\"vlist\\" style=\\"height:1.45em;\\"><span style=\\"top:-3.61em;\\"><span class=\\"pstrut\\" style=\\"height:3em;\\"></span><span class=\\"mord\\"><span class=\\"mord\\">$</span></span></span><span style=\\"top:-2.4099999999999997em;\\"><span class=\\"pstrut\\" style=\\"height:3em;\\"></span><span class=\\"mord\\"><span class=\\"mord\\">$</span></span></span></span><span class=\\"vlist-s\\">​</span></span><span class=\\"vlist-r\\"><span class=\\"vlist\\" style=\\"height:0.9500000000000004em;\\"><span></span></span></span></span></span><span class=\\"arraycolsep\\" style=\\"width:0.5em;\\"></span><span class=\\"arraycolsep\\" style=\\"width:0.5em;\\"></span><span class=\\"col-align-c\\"><span class=\\"vlist-t\\"><span class=\\"vlist-r\\"><span class=\\"vlist\\" style=\\"height:1.45em;\\"><span style=\\"top:-3.61em;\\"><span class=\\"pstrut\\" style=\\"height:3em;\\"></span><span class=\\"mord\\"><span class=\\"mord\\">1</span></span></span></span></span></span></span></span></span><span class=\\"mclose delimcenter\\" style=\\"top:0em;\\"><span class=\\"delimsizing size3\\">)</span></span></span></span></span></span></span>.</p>
 "
 `;
 
-exports[`markdown-it math plugin renders block math composed multiple lines with starting/ending expression on delimited lines 1`] = `
+exports[`markdown-it math plugin for KaTeX renders block math composed multiple lines with starting/ending expression on delimited lines 1`] = `
 "<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\" display=\\"block\\"><semantics><mrow><mo stretchy=\\"false\\">[</mo><mo stretchy=\\"false\\">[</mo><mn>1</mn><mo separator=\\"true\\">,</mo><mn>2</mn><mo stretchy=\\"false\\">]</mo><mo stretchy=\\"false\\">[</mo><mn>3</mn><mo separator=\\"true\\">,</mo><mn>4</mn><mo stretchy=\\"false\\">]</mo><mo stretchy=\\"false\\">]</mo></mrow><annotation encoding=\\"application/x-tex\\">[
 [1, 2]
 [3, 4]
 ]</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:1em;vertical-align:-0.25em;\\"></span><span class=\\"mopen\\">[[</span><span class=\\"mord\\">1</span><span class=\\"mpunct\\">,</span><span class=\\"mspace\\" style=\\"margin-right:0.16666666666666666em;\\"></span><span class=\\"mord\\">2</span><span class=\\"mclose\\">]</span><span class=\\"mopen\\">[</span><span class=\\"mord\\">3</span><span class=\\"mpunct\\">,</span><span class=\\"mspace\\" style=\\"margin-right:0.16666666666666666em;\\"></span><span class=\\"mord\\">4</span><span class=\\"mclose\\">]]</span></span></span></span></span></p>"
 `;
 
-exports[`markdown-it math plugin renders block math with indented up to 3 spaces 1`] = `
+exports[`markdown-it math plugin for KaTeX renders block math with indented up to 3 spaces 1`] = `
 "<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\" display=\\"block\\"><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2
 </annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">2</span></span></span></span></span></p>"
 `;
 
-exports[`markdown-it math plugin renders block math with self-closing at the end of document 1`] = `"<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\" display=\\"block\\"><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">2</span></span></span></span></span></p>"`;
+exports[`markdown-it math plugin for KaTeX renders block math with self-closing at the end of document 1`] = `"<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\" display=\\"block\\"><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">2</span></span></span></span></span></p>"`;
 
-exports[`markdown-it math plugin renders block math written in one line 1`] = `
+exports[`markdown-it math plugin for KaTeX renders block math written in one line 1`] = `
 "<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\" display=\\"block\\"><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2
 </annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">2</span></span></span></span></span></p>"
 `;
 
-exports[`markdown-it math plugin renders math even when it starts with a negative sign 1`] = `
+exports[`markdown-it math plugin for KaTeX renders math even when it starts with a negative sign 1`] = `
 "<p>foo<span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mo>−</mo><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>0</mn></mrow><annotation encoding=\\"application/x-tex\\">-1+1 = 0</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">−</span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">0</span></span></span></span>bar</p>
 "
 `;
 
-exports[`markdown-it math plugin renders math without whitespace before and after delimiter 1`] = `
+exports[`markdown-it math plugin for KaTeX renders math without whitespace before and after delimiter 1`] = `
 "<p>foo<span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">2</span></span></span></span>bar</p>
 "
 `;
 
-exports[`markdown-it math plugin renders multiline display math 1`] = `
+exports[`markdown-it math plugin for KaTeX renders multiline display math 1`] = `
 "<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\" display=\\"block\\"><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">
   1
 + 1
@@ -106,33 +106,33 @@ exports[`markdown-it math plugin renders multiline display math 1`] = `
 </annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">2</span></span></span></span></span></p>"
 `;
 
-exports[`markdown-it math plugin renders multiline inline math 1`] = `
+exports[`markdown-it math plugin for KaTeX renders multiline inline math 1`] = `
 "<p>foo <span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1 + 1
 = 2</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">2</span></span></span></span> bar</p>
 "
 `;
 
-exports[`markdown-it math plugin renders simple block math 1`] = `
+exports[`markdown-it math plugin for KaTeX renders simple block math 1`] = `
 "<p><span class=\\"katex-display\\"><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\" display=\\"block\\"><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2
 </annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">2</span></span></span></span></span></p>"
 `;
 
-exports[`markdown-it math plugin renders simple inline math 1`] = `
+exports[`markdown-it math plugin for KaTeX renders simple inline math 1`] = `
 "<p><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1+1 = 2</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">+</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span><span class=\\"mrel\\">=</span><span class=\\"mspace\\" style=\\"margin-right:0.2777777777777778em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;\\"></span><span class=\\"mord\\">2</span></span></span></span></p>
 "
 `;
 
-exports[`markdown-it math plugin requires a closing delimiter to render math 1`] = `
+exports[`markdown-it math plugin for KaTeX requires a closing delimiter to render math 1`] = `
 "<p>aaa $5.99 bbb</p>
 "
 `;
 
-exports[`markdown-it math plugin requires non whitespace to left of closing inline math 1`] = `
+exports[`markdown-it math plugin for KaTeX requires non whitespace to left of closing inline math 1`] = `
 "<p>I will give you $20 today, if you give me more $ tomorrow.</p>
 "
 `;
 
-exports[`markdown-it math plugin requires non whitespace to right of opening inline math 1`] = `
+exports[`markdown-it math plugin for KaTeX requires non whitespace to right of opening inline math 1`] = `
 "<p>For some Europeans, it is 2$ for a can of soda, not 1$.</p>
 "
 `;

--- a/test/math/katex.ts
+++ b/test/math/katex.ts
@@ -10,10 +10,10 @@ import { markdown as mathPlugin } from '../../src/math/math'
 const countMath = (stt) => stt.split('class="katex"').length - 1
 const countBlockMath = (stt) => stt.split('class="katex-display"').length - 1
 
-describe('markdown-it math plugin', () => {
+describe('markdown-it math plugin for KaTeX', () => {
   const md = new MarkdownIt()
 
-  md.marpit = { options: { math: true } }
+  md.marpit = { options: { math: 'katex' } }
 
   // Mock Marpit instance
   md.use(() => {

--- a/v3.md
+++ b/v3.md
@@ -2,7 +2,8 @@
 
 ### Breaking
 
-- Dropped Node 10 support and now requires the latest version of Node.js v12 and later ([#260](https://github.com/marp-team/marp-core/issues/260), [#266](https://github.com/marp-team/marp-core/issues/266))
+- Dropped Node 10 support and now requires the latest version of Node.js v12 and later ([#260](https://github.com/marp-team/marp-core/issues/260), [#266](https://github.com/marp-team/marp-core/pull/266))
+- Changed the default library for math typesetting from KaTeX to MathJax ([#159](https://github.com/marp-team/marp-core/issues/159), [#236](https://github.com/marp-team/marp-core/issues/236), [#271](https://github.com/marp-team/marp-core/pull/271))
 
 ### Added
 


### PR DESCRIPTION
To avoid troubled KaTeX rendering (#159 and #236), Marp Core v3 will change the default math typesetting library to MathJax.

If you have the slide that is using KaTeX, you can keep using KaTeX by setting `math` global directive as `katex`, 

```markdown
---
math: katex
---
```