### PR TITLE
fix: invalid default text alignment for theme uncover

### DIFF
--- a/themes/uncover.scss
+++ b/themes/uncover.scss
@@ -37,7 +37,6 @@ section {
   line-height: 1.4;
   padding: 30px 70px;
   position: relative;
-  text-align: center;
   width: 1280px;
   word-wrap: break-word;
   z-index: 0;


### PR DESCRIPTION
Hello,

I think it is a copy and paste issue that the uncover theme will auto-apply the `text-center` without class `lead` loaded.

# reference
https://marpit.marp.app/directives?id=class

Best,
Alpha