### PR TITLE
Make compatible with a patched markdown-it-emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Make compatible with a patched markdown-it-emoji ([#294](https://github.com/marp-team/marp-core/pull/294))
+
 ## v3.1.1 - 2022-04-12
 
 > **v3 is still release candidate.** You have to use `next` tag to install: `npm i --save @marp-team/marp-core@next`.

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "emoji-regex": "^10.1.0",
     "highlight.js": "^11.5.1",
     "katex": "^0.15.3",
-    "markdown-it-emoji": "^2.0.0",
+    "markdown-it-emoji": "2.0.0",
     "mathjax-full": "^3.2.0",
     "postcss": "^8.4.12",
     "postcss-minify-params": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "emoji-regex": "^10.1.0",
     "highlight.js": "^11.5.1",
     "katex": "^0.15.3",
-    "markdown-it-emoji": "2.0.0",
+    "markdown-it-emoji": "^2.0.2",
     "mathjax-full": "^3.2.0",
     "postcss": "^8.4.12",
     "postcss-minify-params": "^5.1.2",

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -43,8 +43,8 @@ export const markdown = marpitPlugin((md) => {
     const picker = {
       core: {
         ruler: {
-          push: (_, rule) => (picker.rule = rule),
-          after: (_, __, rule) => (picker.rule = rule),
+          push: (_, rule) => (picker.rule = rule), // for markdown-it-emoji <= v2.0.0
+          after: (_, __, rule) => (picker.rule = rule), // for markdown-it-emoji >= v2.0.1
         },
       },
       renderer: { rules: { emoji: () => {} } }, // eslint-disable-line @typescript-eslint/no-empty-function

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -41,7 +41,12 @@ export const markdown = marpitPlugin((md) => {
   if (opts.shortcode) {
     // Pick rules to avoid collision with other markdown-it plugin
     const picker = {
-      core: { ruler: { push: (_, rule) => (picker.rule = rule) } },
+      core: {
+        ruler: {
+          push: (_, rule) => (picker.rule = rule),
+          after: (_, __, rule) => (picker.rule = rule),
+        },
+      },
       renderer: { rules: { emoji: () => {} } }, // eslint-disable-line @typescript-eslint/no-empty-function
       rule: (() => {}) as (...args: any[]) => void, // eslint-disable-line @typescript-eslint/no-empty-function
       utils: md.utils,
@@ -49,6 +54,7 @@ export const markdown = marpitPlugin((md) => {
 
     markdownItEmoji(picker, { shortcuts: {} })
 
+    // TODO: use md.core.ruler.after in markdown-it v13
     md.core.ruler.push('marp_emoji', (state) => {
       const { Token } = state
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3861,7 +3861,7 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-markdown-it-emoji@^2.0.0:
+markdown-it-emoji@2.0.0, markdown-it-emoji@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-2.0.0.tgz#3164ad4c009efd946e98274f7562ad611089a231"
   integrity sha512-39j7/9vP/CPCKbEI44oV8yoPJTpvfeReTn/COgRhSpNrjWF3PfP/JUxxB0hxV6ynOY8KH8Y8aX9NMDdo6z+6YQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3861,10 +3861,15 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-markdown-it-emoji@2.0.0, markdown-it-emoji@^2.0.0:
+markdown-it-emoji@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-2.0.0.tgz#3164ad4c009efd946e98274f7562ad611089a231"
   integrity sha512-39j7/9vP/CPCKbEI44oV8yoPJTpvfeReTn/COgRhSpNrjWF3PfP/JUxxB0hxV6ynOY8KH8Y8aX9NMDdo6z+6YQ==
+
+markdown-it-emoji@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-2.0.2.tgz#cd42421c2fda1537d9cc12b9923f5c8aeb9029c8"
+  integrity sha512-zLftSaNrKuYl0kR5zm4gxXjHaOI3FAOEaloKmRA5hijmJZvSjmxcokOLlzycb/HXlUFWzXqpIEoyEMCE4i9MvQ==
 
 markdown-it-front-matter@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
The emoji rule picker from markdown-it-emoji is no longer working in [a patched version v2.0.2](https://github.com/markdown-it/markdown-it-emoji/compare/2.0.0...2.0.2) due to the latest markdown-it v13 support. It is breaking downstream Marp CLI installed by `npm`.

Reported at https://github.com/marp-team/marp-cli/issues/445.