### PR TITLE
Fix an empty auto-scaling component becomes unnecessary big

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Apply hydration for custom elements whenever calling browser script ([#305](https://github.com/marp-team/marp-core/pull/305))
+- An empty auto-scaling component becomes unnecessary big ([#306](https://github.com/marp-team/marp-core/pull/306))
 
 ## v3.2.0 - 2022-05-21
 

--- a/src/custom-elements/browser/marp-auto-scaling.ts
+++ b/src/custom-elements/browser/marp-auto-scaling.ts
@@ -44,7 +44,7 @@ export class MarpAutoScaling extends HTMLElement {
     this.shadowRoot.innerHTML = `
 <style>
   svg[${dataSvg}] { display: block; width: 100%; height: auto; vertical-align: top; }
-  span[${dataContainer}] { display: table; white-space: var(--marp-auto-scaling-white-space, nowrap); width: max-content; min-height: 1em; }
+  span[${dataContainer}] { display: table; white-space: var(--marp-auto-scaling-white-space, nowrap); width: max-content; }
 </style>
 <div ${dataWrapper}>
   <svg part="svg" ${dataSvg}>
@@ -133,21 +133,22 @@ export class MarpAutoScaling extends HTMLElement {
   }
 
   private updateSVGRect() {
-    if (!this.containerSize) return
-
-    let width = Math.ceil(this.containerSize.width)
-    const height = Math.ceil(this.containerSize.height)
+    let width = Math.ceil(this.containerSize?.width ?? 0)
+    const height = Math.ceil(this.containerSize?.height ?? 0)
 
     if (this.dataset.downscaleOnly !== undefined) {
-      width = Math.max(width, this.wrapperSize?.width ?? 1)
+      width = Math.max(width, this.wrapperSize?.width ?? 0)
     }
 
     const foreignObject = this.svg?.querySelector(':scope > foreignObject')
     foreignObject?.setAttribute('width', `${width}`)
     foreignObject?.setAttribute('height', `${height}`)
 
-    this.svg?.setAttribute('viewBox', `0 0 ${width} ${height}`)
-    this.svg?.setAttribute('preserveAspectRatio', this.svgPreserveAspectRatio)
+    if (this.svg) {
+      this.svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
+      this.svg.setAttribute('preserveAspectRatio', this.svgPreserveAspectRatio)
+      this.svg.style.height = width <= 0 || height <= 0 ? '0' : ''
+    }
 
     if (this.container) {
       const svgPar = this.svgPreserveAspectRatio.toLowerCase()

--- a/src/custom-elements/browser/marp-auto-scaling.ts
+++ b/src/custom-elements/browser/marp-auto-scaling.ts
@@ -44,7 +44,7 @@ export class MarpAutoScaling extends HTMLElement {
     this.shadowRoot.innerHTML = `
 <style>
   svg[${dataSvg}] { display: block; width: 100%; height: auto; vertical-align: top; }
-  span[${dataContainer}] { display: table; white-space: var(--marp-auto-scaling-white-space, nowrap); width: max-content; }
+  span[${dataContainer}] { display: table; white-space: var(--marp-auto-scaling-white-space, nowrap); width: max-content; min-height: 1em; }
 </style>
 <div ${dataWrapper}>
   <svg part="svg" ${dataSvg}>


### PR DESCRIPTION
Updated `<marp-auto-scaling>` to make no height if the container of contents is empty.