### PR TITLE
Replace Google Fonts in `gaia` theme to Bunny Fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Upgrade Marpit to [v2.4.0](https://github.com/marp-team/marpit/releases/v2.4.0) ([#310](https://github.com/marp-team/marp-core/pull/310))
   - `anchor` constructor option for slide anchor customization
 - Upgrade dependent packages to the latest version ([#310](https://github.com/marp-team/marp-core/pull/310))
+- Replace Google Fonts in `gaia` theme to Bunny Fonts ([#311](https://github.com/marp-team/marp-core/pull/311))
 
 ## v3.2.1 - 2022-06-05
 

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -16,7 +16,7 @@ $color-dark: #455a64;
 $color-primary: #0288d1;
 $color-secondary: #81d4fa;
 
-@import 'https://fonts.googleapis.com/css?family=Lato:400,900|Roboto+Mono:400,700&display=swap';
+@import 'https://fonts.bunny.net/css?family=Lato:400,900|Roboto+Mono:400,700&display=swap';
 @import '~highlight.js/styles/sunburst';
 
 @mixin color-scheme($bg, $text, $highlight) {


### PR DESCRIPTION
`gaia` theme is using Google Fonts for a long time, but currently some of issues are highlighted.

- It allows sending a signal for personal tracking to Google through Google Fonts. The slide author and viewers may be under the risk of GDPR unintentionally.

* Firefox may prevent network access for tracking, including Google Fonts. It brings slide rendering with unexpected fonts, and makes low reproducibllity of slides.

By this update, `gaia` will use [Bunny Fonts](https://bunny.net/fonts/), a drop-in replacement of Google Fonts. It makes clear privacy requirements to compliant with GDPR. Marp users can use Web fonts for slides safely.