### PR TITLE
Apply workaround for vanished <marp-auto-scaling> component in Chrome 105+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Apply workaround for vanished `<marp-auto-scaling>` in Chrome 105+ ([#312](https://github.com/marp-team/marp-core/pull/312))
+
 ## v3.3.0 - 2022-08-11
 
 ### Changed

--- a/src/custom-elements/browser/marp-auto-scaling.ts
+++ b/src/custom-elements/browser/marp-auto-scaling.ts
@@ -70,6 +70,21 @@ export class MarpAutoScaling extends HTMLElement {
         : undefined
     }
 
+    // Workaround for the latest Chromium browser (>= 105?)
+    // TODO: Remove this workaround when the bug is fixed
+    if (this.svg) {
+      const { svg: connectedSvg } = this
+
+      // I don't know why but a nested SVG may require to flush the display style for rendering correctly
+      requestAnimationFrame(() => {
+        connectedSvg.style.display = 'inline'
+
+        requestAnimationFrame(() => {
+          connectedSvg.style.display = ''
+        })
+      })
+    }
+
     this.container =
       this.svg?.querySelector<HTMLSpanElement>(`span[${dataContainer}]`) ??
       undefined

--- a/test/custom-elements/browser.ts
+++ b/test/custom-elements/browser.ts
@@ -263,5 +263,33 @@ describe('The hydration script for custom elements', () => {
       expect(overloaded.container.style.marginRight).toBe('0px')
       expect(overloaded.container.style.marginLeft).toBe('auto')
     })
+
+    describe('Rendering workaround for Chromium 105+', () => {
+      const waitNextRendering = () =>
+        new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+      it("flushes SVG's display style on mounted", async () => {
+        expect.hasAssertions()
+
+        browser.applyCustomElements()
+        document.body.innerHTML = '<marp-auto-scaling>test</marp-auto-scaling>'
+
+        const autoScaling = document.querySelector(
+          'marp-auto-scaling'
+        ) as MarpAutoScaling
+        const svg = autoScaling.shadowRoot.querySelector('svg') as SVGElement
+
+        // Initially SVG's display style is not set
+        expect(svg.style.display).toBe('')
+
+        // At the next rendering frame, display style is set as `inline`
+        await waitNextRendering()
+        expect(svg.style.display).toBe('inline')
+
+        // After that, display style is reverted to empty string
+        await waitNextRendering()
+        expect(svg.style.display).toBe('')
+      })
+    })
   })
 })


### PR DESCRIPTION
I found sometimes the content of `<marp-auto-scaling>` component may not render in the first rendering of Chrome/Chromium 105 beta and later. Computing DOM positions is correct but contents are not painted at the first time.

Because of this problem, [yhatt/marp-cli-example](https://github.com/yhatt/marp-cli-example) is temporally using Chromium 104 provided by the old Puppeteer, instead of the latest Chromium 105.
https://github.com/yhatt/marp-cli-example/commit/b2469408d8aa18d67300515e1f47bbf0272ef516

I don't know the clear reason why, but I guess nested shadow DOMs may prevent painting the content of SVG. Flushing `<svg>` element by changing `display` style will render. Thus, I've patched to `<marp-auto-scaling>` component to flush `display` style on mounted.

By adopting the updated component, I've confirmed to fix vanished auto-scaling content when exporting image by Marp CLI.