### PR TITLE
Bundle external modules used by emoji plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Bundle external modules used by emoji plugin ([#323](https://github.com/marp-team/marp-core/pull/323))
+
 ## v3.4.0 - 2022-11-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "autoprefixer": "^10.4.13",
     "cheerio": "^1.0.0-rc.12",
     "cssnano": "^5.1.14",
+    "emoji-regex": "^10.2.1",
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
@@ -89,6 +90,7 @@
     "jest-junit": "^15.0.0",
     "jest-plugin-context": "^2.9.0",
     "markdown-it": "^13.0.1",
+    "markdown-it-emoji": "^2.0.2",
     "mkdirp": "^1.0.4",
     "nodemon": "^2.0.20",
     "npm-run-all": "^4.1.5",
@@ -110,19 +112,17 @@
     "stylelint-config-standard-scss": "^6.1.0",
     "ts-jest": "29.0.3",
     "tslib": "^2.4.1",
+    "twemoji": "^14.0.2",
     "typescript": "^4.9.3"
   },
   "dependencies": {
     "@marp-team/marpit": "^2.4.2",
     "@marp-team/marpit-svg-polyfill": "^2.0.0",
-    "emoji-regex": "^10.2.1",
     "highlight.js": "^11.6.0",
     "katex": "^0.16.3",
-    "markdown-it-emoji": "^2.0.2",
     "mathjax-full": "^3.2.2",
     "postcss": "^8.4.19",
     "postcss-selector-parser": "^6.0.10",
-    "twemoji": "^14.0.2",
     "xss": "^1.0.14"
   },
   "resolutions": {


### PR DESCRIPTION
Bundled external modules used by Marp Core's emoji plugin.

We had defined external modules related to emoji plugin as `dependency`, to allow developers fix module vulnerabilities by bumping patch version. However, now bundling them might not bring a problem, because twemoji could no longer expect to be updated due to Twitter's product restructuring.

Bundling them can get ready for #320. In addition, can resolve confusion about default export between CJS and ESM in user-side bundler, that was reported at #322.