### PR TITLE
Update `@marp-team/marp-core/browser` script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade marpit-svg-polyfill to [v2.1.0](https://github.com/marp-team/marpit-svg-polyfill/releases/tag/v2.1.0) ([#329](https://github.com/marp-team/marp-core/pull/329))
+
+### Deprecated
+
+- An `observer()` function exported by `@marp-team/marp-core/browser`, which was actually designed for internal ([#330](https://github.com/marp-team/marp-core/pull/330))
+
 ## v3.4.2 - 2023-01-08
 
 ### Fixed

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,6 +1,12 @@
 import { applyCustomElements } from './custom-elements/browser'
 import { observer } from './observer'
-export { observer }
+
+/**
+ * @internal
+ * @deprecated
+ */
+const exportedObserver = observer
+export { exportedObserver as observer }
 
 const marpCoreBrowserScript = Symbol()
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,4 +1,4 @@
-import { polyfills } from '@marp-team/marpit-svg-polyfill'
+import { observe } from '@marp-team/marpit-svg-polyfill'
 
 type ObserverOptions = {
   once?: boolean
@@ -9,19 +9,17 @@ export function observer({
   once = false,
   target = document,
 }: ObserverOptions = {}): () => void {
-  const polyfillFuncs = polyfills()
+  const cleanup = observe(target)
 
-  let enabled = !once
+  if (once) {
+    cleanup()
 
-  const observer = () => {
-    for (const polyfill of polyfillFuncs) polyfill({ target })
-    if (enabled) window.requestAnimationFrame(observer)
+    return () => {
+      /* no ops */
+    }
   }
-  observer()
 
-  return () => {
-    enabled = false
-  }
+  return cleanup
 }
 
 export default observer


### PR DESCRIPTION
- Simplify how to apply an updated `@marp-team/marpit-svg-polyfill`
- Make an internal `observer()` method soft-deprecated (Marp team has no longer used this method in anywhere)