### PR TITLE
Use `@twemoji/api` package instead of `twemoji`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Upgrade Node.js and dependent packages ([#336](https://github.com/marp-team/marp-core/pull/336))
+- Use `@twemoji/api` package instead of `twemoji` ([#337](https://github.com/marp-team/marp-core/pull/337))
 
 ## v3.5.0 - 2023-02-18
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@rollup/plugin-terser": "^0.4.0",
     "@rollup/plugin-typescript": "^11.0.0",
     "@tsconfig/node12": "^1.0.11",
+    "@twemoji/api": "^14.1.2",
     "@types/jest": "^29.5.0",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.56.0",
@@ -112,7 +113,6 @@
     "stylelint-config-standard-scss": "^7.0.1",
     "ts-jest": "29.0.5",
     "tslib": "^2.5.0",
-    "twemoji": "^14.0.2",
     "typescript": "^5.0.2"
   },
   "dependencies": {

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -1,8 +1,7 @@
 import marpitPlugin from '@marp-team/marpit/plugin'
+import twemoji from '@twemoji/api'
 import emojiRegex from 'emoji-regex'
 import markdownItEmoji from 'markdown-it-emoji'
-import twemoji from 'twemoji'
-import { version as twemojiVersion } from 'twemoji/package.json'
 import twemojiCSS from './twemoji.scss'
 
 export interface EmojiOptions {
@@ -29,15 +28,9 @@ export const markdown = marpitPlugin((md) => {
   const twemojiExt = twemojiOpts.ext || 'svg'
 
   const twemojiParse = (content: string): string =>
-    twemoji.parse(content, {
+    // Casting to any is a workaround until merging the PR https://github.com/jdecked/twemoji/pull/1
+    (twemoji as any).parse(content, {
       attributes: () => ({ 'data-marp-twemoji': '' }),
-      // Twemoji's default CDN (MaxCDN) shuts down at December 31, 2022.
-      // Unfortunately, continuous updates of Twemoji (including the update of
-      // base path) can not be expected due to Elon's acquisition for now. So
-      // Marp uses the CDN of jsDelivr unless the user specifies the base path.
-      base: Object.hasOwnProperty.call(twemojiOpts, 'base')
-        ? twemojiOpts.base
-        : `https://cdn.jsdelivr.net/gh/twitter/twemoji@${twemojiVersion}/assets/`,
       ext: `.${twemojiExt}`,
       size: twemojiExt === 'svg' ? 'svg' : undefined,
     })

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -169,7 +169,7 @@ describe('Marp', () => {
 
       it('uses SVG via jsDelivr CDN by default', () => {
         expect(emojiSrc(':ok_hand:')).toMatchInlineSnapshot(
-          `"https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f44c.svg"`
+          `"https://cdn.jsdelivr.net/gh/jdecked/twemoji@14.1.2/assets/svg/1f44c.svg"`
         )
       })
 
@@ -177,13 +177,15 @@ describe('Marp', () => {
         it('uses specified base', () =>
           expect(
             emojiSrc(':+1:', instance({ base: '/assets/twemoji/' }))
-          ).toMatchInlineSnapshot(`"/assets/twemoji/svg/1f44d.svg"`))
+          ).toMatchInlineSnapshot(
+            `"https://cdn.jsdelivr.net/gh/jdecked/twemoji@14.1.2/assets/svg/1f44d.svg"`
+          ))
 
         it("uses Twemoji's default CDN if the base option was undefined", () =>
           expect(
             emojiSrc(':+1:', instance({ base: undefined }))
           ).toMatchInlineSnapshot(
-            `"https://twemoji.maxcdn.com/v/14.0.2/svg/1f44d.svg"`
+            `"https://cdn.jsdelivr.net/gh/jdecked/twemoji@14.1.2/assets/svg/1f44d.svg"`
           ))
       })
 
@@ -192,7 +194,7 @@ describe('Marp', () => {
           expect(
             emojiSrc(':+1:', instance({ ext: 'png' }))
           ).toMatchInlineSnapshot(
-            `"https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f44d.png"`
+            `"https://cdn.jsdelivr.net/gh/jdecked/twemoji@14.1.2/assets/72x72/1f44d.png"`
           ))
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -804,6 +804,16 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
   integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
 
+"@twemoji/api@^14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@twemoji/api/-/api-14.1.2.tgz#9e75a59cc2ff64c6c9106902823c9b6bc5bb4a9f"
+  integrity sha512-JLuszRq7t+NWJTaNwBD+Hbhf67gzn6jAqhNIDTPndEGT55kHiZTJAYRGCHZB/eA58OGVSp7mIvsJs+F/ZDJanA==
+  dependencies:
+    fs-extra "^8.0.1"
+    jsonfile "^5.0.0"
+    twemoji-parser "14.0.0"
+    universalify "^0.1.2"
+
 "@types/babel__core@^7.1.14":
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.0.tgz#61bc5a4cae505ce98e1e36c5445e4bee060d8891"
@@ -5816,16 +5826,6 @@ twemoji-parser@14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-14.0.0.tgz#13dabcb6d3a261d9efbf58a1666b182033bf2b62"
   integrity sha512-9DUOTGLOWs0pFWnh1p6NF+C3CkQ96PWmEFwhOVmT3WbecRC+68AIqpsnJXygfkFcp4aXbOp8Dwbhh/HQgvoRxA==
-
-twemoji@^14.0.2:
-  version "14.0.2"
-  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-14.0.2.tgz#c53adb01dab22bf4870f648ca8cc347ce99ee37e"
-  integrity sha512-BzOoXIe1QVdmsUmZ54xbEH+8AgtOKUiG53zO5vVP2iUu6h5u9lN15NcuS6te4OY96qx0H7JK9vjjl9WQbkTRuA==
-  dependencies:
-    fs-extra "^8.0.1"
-    jsonfile "^5.0.0"
-    twemoji-parser "14.0.0"
-    universalify "^0.1.2"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Twemoji looks like no longer maintained by Twitter due to confusions brought by [Elon's acquisition](https://en.wikipedia.org/wiki/Acquisition_of_Twitter_by_Elon_Musk) (#320).

The original author of Twemoji has [forked the repository](https://github.com/jdecked/twemoji), and now releasing as [`@twemoji/api`](https://www.npmjs.com/package/@twemoji/api). It is also going to support Unicode 15 emojis that were left behind: https://github.com/jdecked/twemoji/issues/8

This PR changes to use `@twemoji/api` packages instead of `twemoji`. By this change, we are going to use an original `base` option provided by the package. (Reverse #321)