### PR TITLE
Follow `@auto-scaling` theme metadata when rendering KaTeX block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Upgrade Marpit to [v2.5.2](https://github.com/marp-team/marpit/releases/v2.5.2) ([#356](https://github.com/marp-team/marp-core/pull/356))
 
+### Fixed
+
+- Regression: Auto-scaling for KaTeX block is always enabled regardless of `@auto-scaling` theme metadata ([#353](https://github.com/marp-team/marp-core/issues/353), [#354](https://github.com/marp-team/marp-core/pull/354))
+
 ## v3.8.0 - 2023-08-01
 
 ### Added

--- a/src/math/katex.ts
+++ b/src/math/katex.ts
@@ -1,5 +1,6 @@
 import katex from 'katex'
 import { version } from 'katex/package.json'
+import { isEnabledAutoScaling } from '../auto-scaling/utils'
 import { getMathContext } from './context'
 import katexScss from './katex.scss'
 
@@ -41,7 +42,7 @@ export const block = (marpit: any) => (tokens, idx) => {
       displayMode: true,
     })
 
-    if (marpit.options.inlineSVG) {
+    if (marpit.options.inlineSVG && isEnabledAutoScaling(marpit, 'math')) {
       rendered = rendered.replace(
         /^<span/i,
         '<span is="marp-span" data-auto-scaling="downscale-only"',

--- a/test/marp.ts
+++ b/test/marp.ts
@@ -861,11 +861,26 @@ function matchwo(a,b)
         expect(pre.text()).toContain('CODE BLOCK')
       })
 
-      it('does not add attributes for pre custom element if disabled disabled inlineSVG mode', () => {
+      it('does not add attributes for pre custom element if disabled inlineSVG mode', () => {
         const $ = loadCheerio(marp({ inlineSVG: false }).render(markdown).html)
         const pre = $('pre')
 
         expect(pre.attr('is')).not.toBe('marp-pre')
+        expect(pre.is('[data-auto-scaling]')).toBe(false)
+        expect(pre.text()).toContain('CODE BLOCK')
+      })
+
+      it('does not add attributes for pre custom element if not enabled auto scaling by theme metadata', () => {
+        const instance = marp()
+        instance.themeSet.add('/* @theme test */')
+
+        const $ = loadCheerio(
+          instance.render(`<!-- theme: test -->\n\n${markdown}`).html,
+        )
+        const pre = $('pre')
+
+        expect(pre.attr('is')).not.toBe('marp-pre')
+        expect(pre.is('[data-auto-scaling]')).toBe(false)
         expect(pre.text()).toContain('CODE BLOCK')
       })
     })
@@ -883,11 +898,26 @@ function matchwo(a,b)
         expect(pre.text()).toContain('const a = 1')
       })
 
-      it('does not add attributes for pre custom element if disabled disabled inlineSVG mode', () => {
+      it('does not add attributes for pre custom element if disabled inlineSVG mode', () => {
         const $ = loadCheerio(marp({ inlineSVG: false }).render(markdown).html)
         const pre = $('pre')
 
         expect(pre.attr('is')).not.toBe('marp-pre')
+        expect(pre.is('[data-auto-scaling]')).toBe(false)
+        expect(pre.text()).toContain('const a = 1')
+      })
+
+      it('does not add attributes for pre custom element if not enabled auto scaling by theme metadata', () => {
+        const instance = marp()
+        instance.themeSet.add('/* @theme test */')
+
+        const $ = loadCheerio(
+          instance.render(`<!-- theme: test -->\n\n${markdown}`).html,
+        )
+        const pre = $('pre')
+
+        expect(pre.attr('is')).not.toBe('marp-pre')
+        expect(pre.is('[data-auto-scaling]')).toBe(false)
         expect(pre.text()).toContain('const a = 1')
       })
     })
@@ -904,9 +934,22 @@ function matchwo(a,b)
         expect(katex.is('[data-auto-scaling="downscale-only"]')).toBe(true)
       })
 
-      it('does not add attributes for span custom element if disabled disabled inlineSVG mode', () => {
+      it('does not add attributes for span custom element if disabled inlineSVG mode', () => {
         const $ = loadCheerio(
           marp({ math: 'katex', inlineSVG: false }).render(markdown).html,
+        )
+        const katex = $('span.katex-display')
+
+        expect(katex.attr('is')).not.toBe('marp-span')
+        expect(katex.is('[data-auto-scaling]')).toBe(false)
+      })
+
+      it('does not add attributes for span custom element if not enabled auto scaling by theme metadata', () => {
+        const instance = marp({ math: 'katex' })
+        instance.themeSet.add('/* @theme test */')
+
+        const $ = loadCheerio(
+          instance.render(`<!-- theme: test -->\n\n${markdown}`).html,
         )
         const katex = $('span.katex-display')
 
@@ -918,6 +961,7 @@ function matchwo(a,b)
         it('does not use custom element because it has already supported auto-scaling', () => {
           const $ = loadCheerio(marp({ math: 'mathjax' }).render(markdown).html)
           expect($('[is="marp-span"]')).toHaveLength(0)
+          expect($('[data-auto-scaling]')).toHaveLength(0)
         })
       })
     })


### PR DESCRIPTION
Fix #353.