### PR TITLE
[v5] Refactor Marp internal plugin generator for Marpit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@tsdown/css": "^0.21.4",
         "@twemoji/api": "^17.0.2",
         "@types/jest": "^30.0.0",
+        "@types/markdown-it": "^14.1.2",
         "autoprefixer": "^10.4.27",
         "cheerio": "^1.2.0",
         "cssnano": "^7.1.3",
@@ -4075,6 +4076,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -4083,6 +4102,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.3.2",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@tsdown/css": "^0.21.4",
     "@twemoji/api": "^17.0.2",
     "@types/jest": "^30.0.0",
+    "@types/markdown-it": "^14.1.2",
     "autoprefixer": "^10.4.27",
     "cheerio": "^1.2.0",
     "cssnano": "^7.1.3",

--- a/src/auto-scaling/code-block.ts
+++ b/src/auto-scaling/code-block.ts
@@ -1,15 +1,19 @@
-import marpitPlugin from '@marp-team/marpit/plugin.js'
+import type MarkdownIt from 'markdown-it'
+import { marpPlugin } from '../plugin'
 import { isEnabledAutoScaling } from './utils'
 
 const codeMatcher = /^(<pre[^>]*?><code[^>]*?>)([\s\S]*)(<\/code><\/pre>\n*)$/
 
-export const codeBlockPlugin = marpitPlugin((md) => {
+export const codeBlockPlugin = marpPlugin((md) => {
   const { code_block, fence } = md.renderer.rules
 
   const replacedRenderer =
-    (func: (...args: any[]) => string) =>
-    (...args: any[]) => {
-      const rendered = func(...args)
+    (func?: MarkdownIt.Renderer.RenderRule): MarkdownIt.Renderer.RenderRule =>
+    (tokens, idx, options, env, self) => {
+      const rendered = func
+        ? func(tokens, idx, options, env, self)
+        : self.renderToken(tokens, idx, options)
+
       const shouldScale =
         md.marpit.options.inlineSVG && isEnabledAutoScaling(md.marpit, 'code')
 

--- a/src/auto-scaling/code-block.ts
+++ b/src/auto-scaling/code-block.ts
@@ -8,12 +8,9 @@ export const codeBlockPlugin = marpPlugin((md) => {
   const { code_block, fence } = md.renderer.rules
 
   const replacedRenderer =
-    (func?: MarkdownIt.Renderer.RenderRule): MarkdownIt.Renderer.RenderRule =>
+    (func: MarkdownIt.Renderer.RenderRule): MarkdownIt.Renderer.RenderRule =>
     (tokens, idx, options, env, self) => {
-      const rendered = func
-        ? func(tokens, idx, options, env, self)
-        : self.renderToken(tokens, idx, options)
-
+      const rendered = func(tokens, idx, options, env, self)
       const shouldScale =
         md.marpit.options.inlineSVG && isEnabledAutoScaling(md.marpit, 'code')
 
@@ -29,6 +26,9 @@ export const codeBlockPlugin = marpPlugin((md) => {
       )
     }
 
-  md.renderer.rules.code_block = replacedRenderer(code_block)
-  md.renderer.rules.fence = replacedRenderer(fence)
+  // markdown-it has default renderer rules for code_block and fence, so we can treat them as non-nullable
+  // https://github.com/markdown-it/markdown-it/blob/a6d1d484e521ec37a671ae4d07c09169f9a8f9af/lib/renderer.mjs#L21
+  // https://github.com/markdown-it/markdown-it/blob/a6d1d484e521ec37a671ae4d07c09169f9a8f9af/lib/renderer.mjs#L29
+  md.renderer.rules.code_block = replacedRenderer(code_block!)
+  md.renderer.rules.fence = replacedRenderer(fence!)
 })

--- a/src/auto-scaling/fitting-header.ts
+++ b/src/auto-scaling/fitting-header.ts
@@ -1,13 +1,14 @@
-import marpitPlugin from '@marp-team/marpit/plugin.js'
+import type MarkdownIt from 'markdown-it'
+import { marpPlugin } from '../plugin'
 import { isEnabledAutoScaling } from './utils'
 
-export const fittingHeaderPlugin = marpitPlugin((md) => {
+export const fittingHeaderPlugin = marpPlugin((md) => {
   const { heading_open } = md.renderer.rules
 
   md.core.ruler.after('inline', 'marp_fitting_header', ({ tokens }) => {
     if (!md.marpit.options.inlineSVG) return
 
-    let target: any = undefined
+    let target: MarkdownIt.Token | undefined
 
     for (const token of tokens) {
       if (!target && token.type === 'heading_open') target = token
@@ -16,7 +17,7 @@ export const fittingHeaderPlugin = marpitPlugin((md) => {
         if (token.type === 'inline') {
           let autoScalingRequired = false
 
-          for (const t of token.children) {
+          for (const t of token.children ?? []) {
             if (t.type === 'marpit_comment' && t.content === 'fit') {
               autoScalingRequired = true
 

--- a/src/auto-scaling/index.ts
+++ b/src/auto-scaling/index.ts
@@ -1,7 +1,7 @@
-import marpitPlugin from '@marp-team/marpit/plugin.js'
+import { marpPlugin } from '../plugin'
 import { codeBlockPlugin } from './code-block'
 import { fittingHeaderPlugin } from './fitting-header'
 
-export const markdown = marpitPlugin((md) =>
+export const markdown = marpPlugin((md) =>
   md.use(fittingHeaderPlugin).use(codeBlockPlugin),
 )

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -48,7 +48,7 @@ export const markdown = marpPlugin((md) => {
         },
       },
       renderer: { rules: {} as { emoji: () => string } },
-      rule: (() => {}) as MarkdownIt.Core.RuleCore,
+      rule: (() => void 0) as MarkdownIt.Core.RuleCore,
       utils: md.utils,
     }
 
@@ -133,24 +133,10 @@ export const markdown = marpPlugin((md) => {
 
       md.renderer.rules.marp_unicode_emoji = twemojiRenderer
 
-      md.renderer.rules.code_inline = (tokens, idx, options, env, self) =>
-        wrap(
-          code_inline
-            ? code_inline(tokens, idx, options, env, self)
-            : self.renderToken(tokens, idx, options),
-        )
-      md.renderer.rules.code_block = (tokens, idx, options, env, self) =>
-        wrap(
-          code_block
-            ? code_block(tokens, idx, options, env, self)
-            : self.renderToken(tokens, idx, options),
-        )
-      md.renderer.rules.fence = (tokens, idx, options, env, self) =>
-        wrap(
-          fence
-            ? fence(tokens, idx, options, env, self)
-            : self.renderToken(tokens, idx, options),
-        )
+      // markdown-it has default renderer rules for code_inline, code_block and fence, so we can treat them as non-nullable
+      md.renderer.rules.code_inline = (...rest) => wrap(code_inline!(...rest))
+      md.renderer.rules.code_block = (...rest) => wrap(code_block!(...rest))
+      md.renderer.rules.fence = (...rest) => wrap(fence!(...rest))
     }
   }
 })

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -44,11 +44,10 @@ export const markdown = marpPlugin((md) => {
     const picker = {
       core: {
         ruler: {
-          push: (_, rule) => (picker.rule = rule), // for markdown-it-emoji <= v2.0.0
-          after: (_, __, rule) => (picker.rule = rule), // for markdown-it-emoji >= v2.0.1
+          after: (_, __, rule) => (picker.rule = rule),
         },
       },
-      renderer: { rules: { emoji: (): string => '' } },
+      renderer: { rules: {} as { emoji: () => string } },
       rule: (() => {}) as MarkdownIt.Core.RuleCore,
       utils: md.utils,
     }

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -1,7 +1,8 @@
-import marpitPlugin from '@marp-team/marpit/plugin.js'
 import twemoji from '@twemoji/api'
 import emojiRegex from 'emoji-regex'
+import type MarkdownIt from 'markdown-it'
 import { full as markdownItEmoji } from 'markdown-it-emoji'
+import { marpPlugin } from '../plugin'
 import twemojiCSS from './twemoji.scss?inline'
 
 export interface EmojiOptions {
@@ -22,7 +23,7 @@ export const css = (opts: EmojiOptions) =>
     ? twemojiCSS
     : undefined
 
-export const markdown = marpitPlugin((md) => {
+export const markdown = marpPlugin((md) => {
   const opts: EmojiOptions = md.marpit.options.emoji
   const twemojiOpts = opts.twemoji || {}
   const twemojiExt = twemojiOpts.ext || 'svg'
@@ -35,8 +36,8 @@ export const markdown = marpitPlugin((md) => {
       size: twemojiExt === 'svg' ? 'svg' : undefined,
     })
 
-  const twemojiRenderer = (token: any[], idx: number): string =>
-    twemojiParse(token[idx].content)
+  const twemojiRenderer: MarkdownIt.Renderer.RenderRule = (tokens, idx) =>
+    twemojiParse(tokens[idx].content)
 
   if (opts.shortcode) {
     // Pick rules to avoid collision with other markdown-it plugin
@@ -47,8 +48,8 @@ export const markdown = marpitPlugin((md) => {
           after: (_, __, rule) => (picker.rule = rule), // for markdown-it-emoji >= v2.0.1
         },
       },
-      renderer: { rules: { emoji: () => {} } },
-      rule: (() => {}) as (...args: any[]) => void,
+      renderer: { rules: { emoji: (): string => '' } },
+      rule: (() => {}) as MarkdownIt.Core.RuleCore,
       utils: md.utils,
     }
 
@@ -58,9 +59,9 @@ export const markdown = marpitPlugin((md) => {
     md.core.ruler.push('marp_emoji', (state) => {
       const { Token } = state
 
-      state.Token = function replacedToken(name, ...args) {
-        return new Token(name === 'emoji' ? 'marp_emoji' : name, ...args)
-      }
+      state.Token = function replacedToken(type, tag, nesting) {
+        return new Token(type === 'emoji' ? 'marp_emoji' : type, tag, nesting)
+      } as unknown as typeof Token
 
       picker.rule(state)
       state.Token = Token
@@ -76,20 +77,20 @@ export const markdown = marpitPlugin((md) => {
     md.core.ruler.after('inline', 'marp_unicode_emoji', ({ tokens, Token }) => {
       for (const token of tokens) {
         if (token.type === 'inline') {
-          const newChildren: any[] = []
+          const newChildren: MarkdownIt.Token[] = []
 
-          for (const t of token.children) {
+          for (const t of token.children ?? []) {
             if (t.type === 'text') {
               const splittedByEmoji = t.content.split(regexForSplit)
 
               newChildren.push(
-                ...splittedByEmoji.reduce(
+                ...splittedByEmoji.reduce<MarkdownIt.Token[]>(
                   (splitArr, text, idx) =>
                     text.length === 0
                       ? splitArr
                       : [
                           ...splitArr,
-                          Object.assign(new Token(), {
+                          Object.assign(new Token(t.type, t.tag, t.nesting), {
                             ...t,
                             content: text,
                             type: idx % 2 ? 'marp_unicode_emoji' : 'text',
@@ -109,14 +110,14 @@ export const markdown = marpitPlugin((md) => {
     })
 
     md.renderer.rules.marp_unicode_emoji = (
-      token: any[],
+      token: MarkdownIt.Token[],
       idx: number,
     ): string => token[idx].content
 
     const { code_block, code_inline, fence } = md.renderer.rules
 
     if (opts.unicode === 'twemoji') {
-      const wrap = (text) =>
+      const wrap = (text: string): string =>
         text
           .split(/(<[^>]*>)/g)
           .reduce(
@@ -133,9 +134,24 @@ export const markdown = marpitPlugin((md) => {
 
       md.renderer.rules.marp_unicode_emoji = twemojiRenderer
 
-      md.renderer.rules.code_inline = (...args) => wrap(code_inline(...args))
-      md.renderer.rules.code_block = (...args) => wrap(code_block(...args))
-      md.renderer.rules.fence = (...args) => wrap(fence(...args))
+      md.renderer.rules.code_inline = (tokens, idx, options, env, self) =>
+        wrap(
+          code_inline
+            ? code_inline(tokens, idx, options, env, self)
+            : self.renderToken(tokens, idx, options),
+        )
+      md.renderer.rules.code_block = (tokens, idx, options, env, self) =>
+        wrap(
+          code_block
+            ? code_block(tokens, idx, options, env, self)
+            : self.renderToken(tokens, idx, options),
+        )
+      md.renderer.rules.fence = (tokens, idx, options, env, self) =>
+        wrap(
+          fence
+            ? fence(tokens, idx, options, env, self)
+            : self.renderToken(tokens, idx, options),
+        )
     }
   }
 })

--- a/src/emoji/emoji.ts
+++ b/src/emoji/emoji.ts
@@ -48,7 +48,7 @@ export const markdown = marpPlugin((md) => {
         },
       },
       renderer: { rules: {} as { emoji: () => string } },
-      rule: (() => void 0) as MarkdownIt.Core.RuleCore,
+      rule: null as unknown as MarkdownIt.Core.RuleCore,
       utils: md.utils,
     }
 

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -1,5 +1,5 @@
-import marpitPlugin from '@marp-team/marpit/plugin.js'
 import { Marp } from '../marp'
+import { marpPlugin } from '../plugin'
 import { getMathContext, setMathContext } from './context'
 import * as katex from './katex'
 import * as mathjax from './mathjax'
@@ -17,7 +17,7 @@ export type MathOptions = boolean | MathPreferredLibrary | MathOptionsInterface
 const defaultLibrary = 'mathjax' as const
 const getLibrary = (opts: MathOptionsInterface) => opts.lib ?? defaultLibrary
 
-export const markdown = marpitPlugin((md) => {
+export const markdown = marpPlugin((md) => {
   const marp: Marp = md.marpit
   const opts: MathOptions | undefined = marp.options.math
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,23 @@
+import type MarkdownIt from 'markdown-it'
+import type { Marp } from './marp'
+
+export type MarpPlugin<Params extends unknown[] = []> = (
+  this: MarpPlugin<Params>,
+  md: MarkdownIt & { marpit: Marp },
+  ...params: Params
+) => void
+
+export function marpPlugin<Params extends unknown[]>(
+  plugin: MarpPlugin<Params>,
+) {
+  const generatedPlugin: MarpPlugin<Params> = function (this, md, ...params) {
+    if ('marpit' in md && md.marpit) return plugin.call(plugin, md, ...params)
+
+    throw new Error(
+      'Marp plugin has detected incompatible markdown-it instance.',
+    )
+  }
+
+  // Return generated plugin as a compatible type with markdown-it plugin
+  return generatedPlugin as (md: MarkdownIt, ...params: Params) => void
+}

--- a/src/size/size.ts
+++ b/src/size/size.ts
@@ -1,6 +1,6 @@
 import { Theme } from '@marp-team/marpit'
-import marpitPlugin from '@marp-team/marpit/plugin.js'
 import { Marp } from '../marp'
+import { marpPlugin } from '../plugin'
 
 interface DefinedSize {
   width: string
@@ -14,7 +14,7 @@ interface RestorableThemes {
 
 const sizePluginSymbol = Symbol('marp-size-plugin')
 
-export const markdown = marpitPlugin((md) => {
+export const markdown = marpPlugin((md) => {
   const marp: Marp = md.marpit
   const { render } = marp
 

--- a/src/slug/slug.ts
+++ b/src/slug/slug.ts
@@ -1,5 +1,5 @@
-import marpitPlugin from '@marp-team/marpit/plugin.js'
 import type { Marp } from '../marp'
+import { marpPlugin } from '../plugin'
 
 export type Slugifier = (text: string) => string
 export type PostSlugify = (slug: string, index: number) => string
@@ -42,7 +42,7 @@ const parseSlugOptions = (
     : { ...defaultSlugOptions, ...options }
 }
 
-export const markdown = marpitPlugin((md) => {
+export const markdown = marpPlugin((md) => {
   const marp: Marp = md.marpit
 
   md.core.ruler.push('marp_slug', (state) => {

--- a/test/auto-scaling/code-block.ts
+++ b/test/auto-scaling/code-block.ts
@@ -1,0 +1,64 @@
+import { Marpit } from '@marp-team/marpit'
+import type { Options } from '@marp-team/marpit'
+import { load } from 'cheerio'
+import MarkdownIt from 'markdown-it'
+import { codeBlockPlugin } from '../../src/auto-scaling/code-block'
+
+jest.mock('../../src/auto-scaling/utils', () => ({
+  // Always enable auto-scaling for testing
+  isEnabledAutoScaling: jest.fn().mockReturnValue(true),
+}))
+
+describe('Auto scaling code block plugin', () => {
+  const instance = (opts: Options = {}) =>
+    new Marpit({ inlineSVG: true, ...opts }).use(codeBlockPlugin)
+
+  it('renders auto-scaling tag for indented code block', () => {
+    const { html } = instance().render('    CODE BLOCK')
+    const pre = load(html)('pre')
+
+    expect(pre).toHaveLength(1)
+    expect(pre.attr('is')).toBe('marp-pre')
+    expect(pre.attr('data-auto-scaling')).toBe('downscale-only')
+    expect(pre.text()).toContain('CODE BLOCK')
+  })
+
+  it('renders auto-scaling tag for fenced code block', () => {
+    const { html } = instance().render('```ts\nconst foo = "bar"\n```')
+    const pre = load(html)('pre')
+
+    expect(pre).toHaveLength(1)
+    expect(pre.attr('is')).toBe('marp-pre')
+    expect(pre.attr('data-auto-scaling')).toBe('downscale-only')
+    expect(pre.text()).toContain('const foo = "bar"')
+  })
+
+  it("does not render auto-scaling tag when Marpit's inline SVG mode is disabled", () => {
+    const { html } = instance({ inlineSVG: false }).render('    CODE BLOCK')
+    const pre = load(html)('pre')
+
+    expect(pre).toHaveLength(1)
+    expect(pre.attr('is')).toBeUndefined()
+    expect(pre.attr('data-auto-scaling')).toBeUndefined()
+  })
+
+  it('renders auto-scaling tag with custom code block renderer', () => {
+    const marpit = instance({
+      markdown: new MarkdownIt().use((md) => {
+        const defaultCodeBlock = md.renderer.rules.code_block!
+
+        md.renderer.rules.code_block = function (tokens, idx, opts, env, self) {
+          const html = defaultCodeBlock.call(this, tokens, idx, opts, env, self)
+          return html.replace('<pre', '<pre data-custom-renderer').trim()
+        }
+      }),
+    })
+
+    const { html } = marpit.render('    CODE BLOCK')
+    const pre = load(html)('pre')
+
+    expect(pre.attr('data-custom-renderer')).toBe('')
+    expect(pre.attr('is')).toBe('marp-pre')
+    expect(pre.attr('data-auto-scaling')).toBe('downscale-only')
+  })
+})

--- a/test/auto-scaling/fitting-header.ts
+++ b/test/auto-scaling/fitting-header.ts
@@ -1,0 +1,62 @@
+import { Marpit } from '@marp-team/marpit'
+import type { Options } from '@marp-team/marpit'
+import MarkdownIt from 'markdown-it'
+import { fittingHeaderPlugin } from '../../src/auto-scaling/fitting-header'
+
+jest.mock('../../src/auto-scaling/utils', () => ({
+  // Always enable auto-scaling for testing
+  isEnabledAutoScaling: jest.fn().mockReturnValue(true),
+}))
+
+describe('Auto scaling fitting header plugin', () => {
+  const instance = (opts: Options = {}) =>
+    new Marpit({ inlineSVG: true, ...opts }).use(fittingHeaderPlugin)
+
+  it('does not render auto-scaling tag when the header is not annotated', () => {
+    const { html } = instance().render('# heading')
+
+    expect(html).toContain('<h1>')
+    expect(html).not.toContain('data-auto-scaling')
+  })
+
+  it('renders auto-scaling tag when the header is annotated', () => {
+    const { html, comments } = instance().render('# heading <!--fit-->')
+
+    expect(html).toContain('<h1 is="marp-h1" data-auto-scaling>')
+    expect(comments[0]).toHaveLength(0) // Annotation comment should be removed from the output
+  })
+
+  it('does not render auto-scaling tag when the annotated token is not a heading', () => {
+    const { html } = instance().render('text <!--fit-->')
+
+    expect(html).not.toContain('data-auto-scaling')
+  })
+
+  it("does not render auto-scaling tag when Marpit's inline SVG mode is disabled", () => {
+    const { html, comments } = instance({ inlineSVG: false }).render(
+      '# heading <!--fit-->',
+    )
+
+    expect(html).toContain('<h1>')
+    expect(html).not.toContain('data-auto-scaling')
+    expect(comments[0]).toStrictEqual(['fit']) // Annotation comment should be preserved in the output
+  })
+
+  it('renders auto-scaling tag with custom renderer', () => {
+    const marpit = instance({
+      markdown: new MarkdownIt().use((md) => {
+        md.renderer.rules.heading_open = (tokens, idx, opts, _env, self) =>
+          `<div data-custom-renderer>${self.renderToken(tokens, idx, opts).trim()}`
+
+        md.renderer.rules.heading_close = (tokens, idx, opts, _env, self) =>
+          `${self.renderToken(tokens, idx, opts).trim()}</div>`
+      }),
+    })
+    const { html } = marpit.render('# heading <!--fit-->')
+
+    expect(html).toContain(
+      '<div data-custom-renderer><h1 is="marp-h1" data-auto-scaling>',
+    )
+    expect(html).toContain('</h1></div>')
+  })
+})

--- a/test/emoji/emoji.ts
+++ b/test/emoji/emoji.ts
@@ -1,0 +1,69 @@
+import { Marpit } from '@marp-team/marpit'
+import type { Options as MarpitOptions } from '@marp-team/marpit'
+import { load } from 'cheerio'
+import MarkdownIt from 'markdown-it'
+import { markdown as emojiPlugin } from '../../src/emoji/emoji'
+import type { MarpOptions } from '../../src/marp'
+
+describe('Emoji plugin', () => {
+  const instance = (opts: MarpOptions = {}) =>
+    new Marpit(opts as MarpitOptions).use(emojiPlugin)
+
+  it('converts shortcode to unicode emoji', () => {
+    const marpit = instance({ emoji: { shortcode: true } })
+    const { html } = marpit.render('# :heart:')
+    const $ = load(html)
+
+    expect($('h1').text()).toBe('\u2764\ufe0f')
+  })
+
+  it('converts unicode emoji in code elements to twemoji image', () => {
+    const marpit = instance({ emoji: { unicode: 'twemoji' } })
+
+    const $inline = load(marpit.render('`👍`').html)
+    expect($inline('code img[data-marp-twemoji][alt="👍"]')).toHaveLength(1)
+
+    const $block = load(marpit.render('    👍').html)
+    expect($block('pre code img[data-marp-twemoji][alt="👍"]')).toHaveLength(1)
+
+    const $fence = load(marpit.render('```text\n👍\n```').html)
+    expect($fence('pre code img[data-marp-twemoji][alt="👍"]')).toHaveLength(1)
+  })
+
+  it('keeps custom code renderers while converting unicode emoji to twemoji image', () => {
+    const marpit = instance({
+      emoji: { unicode: 'twemoji' },
+      markdown: new MarkdownIt().use((md) => {
+        const { code_inline, code_block, fence } = md.renderer.rules
+
+        md.renderer.rules.code_inline = (...rest) =>
+          `<span data-custom-inline>${code_inline?.(...rest).trim()}</span>`
+
+        md.renderer.rules.code_block = (...rest) =>
+          `<div data-custom-block>${code_block?.(...rest).trim()}</div>`
+
+        md.renderer.rules.fence = (...rest) =>
+          `<div data-custom-fence>${fence?.(...rest).trim()}</div>`
+      }),
+    })
+
+    const $inline = load(marpit.render('`👍`').html)
+    expect(
+      $inline('span[data-custom-inline] code img[data-marp-twemoji][alt="👍"]'),
+    ).toHaveLength(1)
+
+    const $block = load(marpit.render('    👍').html)
+    expect(
+      $block(
+        'div[data-custom-block] pre code img[data-marp-twemoji][alt="👍"]',
+      ),
+    ).toHaveLength(1)
+
+    const $fence = load(marpit.render('```text\n👍\n```').html)
+    expect(
+      $fence(
+        'div[data-custom-fence] pre code.language-text img[data-marp-twemoji][alt="👍"]',
+      ),
+    ).toHaveLength(1)
+  })
+})

--- a/test/plugin.ts
+++ b/test/plugin.ts
@@ -1,0 +1,27 @@
+import { Marpit } from '@marp-team/marpit'
+import MarkdownIt from 'markdown-it'
+import { marpPlugin } from '../src/plugin'
+
+describe('Plugin helper', () => {
+  it('passes through for Marpit compatible instance', () => {
+    const marpit = new Marpit()
+    const fn = jest.fn()
+    const plugin = marpPlugin(fn)
+
+    marpit.use(plugin)
+    expect(fn).toHaveBeenCalled()
+
+    const calledThis = fn.mock.contexts[0]
+    expect(calledThis).toBe(fn)
+  })
+
+  it('throws for incompatible markdown-it instance', () => {
+    const md = new MarkdownIt()
+    const fn = jest.fn()
+    const plugin = marpPlugin(fn)
+
+    expect(() => md.use(plugin)).toThrow(
+      'Marp plugin has detected incompatible markdown-it instance.',
+    )
+  })
+})


### PR DESCRIPTION
By changing bundle from rollup to tsdown, importing `@marp-team/marpit/plugin` now requires an extension `.js`, and it resolves the type as `any`.

This PR refactors a generator for Marpit internal plugins used by Marp Core to be type-safer.