### PR TITLE
Mitigate incomplete PDF rendering on the `gaia` theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Mitigate incomplete PDF rendering on the `gaia` theme ([#424](https://github.com/marp-team/marp-core/pull/424))
+
+> [!NOTE]
+> The background color no longer changes when applying only the `background-color` style to the `gaia` theme. Use the `background` shorthand style, [`--color-background` CSS variable for the `gaia` theme](./themes/README.md#custom-color-css-variables-1), or [`backgroundColor` Markdown directive](https://marpit.marp.app/directives?id=backgrounds) instead.
+
 ## v4.3.1 - 2026-07-04
 
 ### Changed

--- a/themes/gaia.scss
+++ b/themes/gaia.scss
@@ -193,10 +193,10 @@ section {
   background-color: var(--color-background);
   background-image: linear-gradient(
     135deg,
-    rgba(#888, 0),
-    rgba(#888, 0.02) 50%,
-    rgba(#fff, 0) 50%,
-    rgba(#fff, 0.05)
+    var(--color-background),
+    color-mix(in srgb, var(--color-background) 98%, #888 2%) 50%,
+    var(--color-background) 50%,
+    color-mix(in srgb, var(--color-background) 95%, #fff 5%)
   );
   color: var(--color-foreground);
   font-size: 35px;

--- a/themes/uncover.scss
+++ b/themes/uncover.scss
@@ -75,6 +75,18 @@ section {
     text-align: right;
     text-shadow: 0 0 5px var(--color-background);
     width: 80px;
+
+    /* Workaround: Firefox drops gradient alpha when exporting PDF
+     * https://bugzilla.mozilla.org/show_bug.cgi?id=1529152 */
+    @media print {
+      /* -moz-context-properties is only enabled if `svg.context-properties.content.enabled` is `true` in `about:config`.
+       * Marp CLI's Puppeteer should set this preference to `true` for getting correct PDF output. */
+      @supports (-moz-context-properties: fill) {
+        -moz-context-properties: fill;
+        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"><path d="M0 1h1V0Z" fill="context-fill"/></svg>');
+        fill: var(--color-background-paginate);
+      }
+    }
   }
 
   &:where(.invert) {


### PR DESCRIPTION
This PR updates the default slide background gradient of the `gaia` theme. It replaces the semi-transparent gradient layered over the background color with an opaque gradient whose colors are derived from the `color-mix()` function and the `--color-background` CSS variable.

This change addresses the following issues on macOS:

- When exporting PDF slides using the `gaia` theme with Marp CLI's `--browser=firefox` option, the slide background is rendered incorrectly due to [Firefox Bug 2000439](https://bugzilla.mozilla.org/show_bug.cgi?id=2000439). It means Marp users could not use Firefox browser as an alternative renderer for `gaia` theme slides.
  
  |Before|After|
  |---|---|
  |<img width="1280" height="720" alt="gaia-before" src="https://github.com/user-attachments/assets/ed053c04-542c-414e-a95c-969f4d91951d" />|<img width="1280" height="720" alt="gaia-after" src="https://github.com/user-attachments/assets/23a7c9f5-5e55-49ad-9a6b-b819c593a3f4" />|



* In Chromium-generated PDFs, the semi-transparent gradient covering the entire slide background is represented using a PostScript calculator function and a luminosity soft mask. Evaluating this representation makes PDF rendering extremely slow in Core Graphics on macOS (e.g. Preview.app).

### Minor breaking change

If using the custom `background-color` style on `gaia` theme by expecting gradient overlay, the author should replace it to [`--color-background` CSS variable](https://github.com/marp-team/marp-core/tree/main/themes#custom-color-css-variables-1) or just `background` declaration instead.

```css
@import 'gaia';

section {
  /* background-color: #fed; */ /* ❌ No longer working */

  --color-background: #fed; /* 🅰️ A right way for theme customization of `gaia` theme */

  background: #fed; /* 🅱️ A declaration for setting the background color and remove gradient image at once */
}
```

`backgroundColor` directive provided by Marpit framework is still working correctly, because it removes the gradient image to get ensure the specified background color.

> [!NOTE]
> This change may break existing slides, but since the benefits of improved PDF rendering outweigh the potential impact, it will be introduced in a minor update.